### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
   # ===========================================================================
   windows:
     name: Windows
+    permissions:
+      contents: read
     runs-on: windows-latest
     continue-on-error: true  # swift-nio-ssl Windows header issues
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/KrisSimon/aro/security/code-scanning/4](https://github.com/KrisSimon/aro/security/code-scanning/4)

To fix this problem, explicitly add a `permissions` block to the `windows` job, specifying the minimal set of privileges required for the job's steps. In this context, since the steps are limited to checking out code (`actions/checkout`), running builds/tests, and uploading artifacts (`actions/upload-artifact`), only read access to repository contents is needed. Therefore, we should add `permissions: contents: read` under the `windows` job definition. The block should be inserted immediately beneath the `name: Windows` (line 116), before the `runs-on:` line, as per YAML best practices and GitHub Actions schema.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
