### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,6 +34,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/KrisSimon/aro/security/code-scanning/1](https://github.com/KrisSimon/aro/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the `build` job within `.github/workflows/website.yml`. The recommended minimal permissions for build jobs are `contents: read`, unless there is a clear reason to need more. This block should be placed under the `runs-on` line for the `build` job (typically after line 36). No extra methods or code logic are needed; only the new YAML key needs to be added. This change will reduce the GitHub Actions token scope for this job and help secure the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
