### PR TITLE
feat: Add Package.swift plugin support and ZipService example

### DIFF
--- a/Documentation/LanguageGuide/Services.md
+++ b/Documentation/LanguageGuide/Services.md
@@ -176,60 +176,134 @@ When ARO is distributed as a pre-compiled binary, users can add custom services 
 
 ### Plugin Structure
 
+Plugins can be either single Swift files or Swift packages with dependencies:
+
+**Simple Plugin (single file):**
 ```
 MyApp/
 ├── main.aro
 ├── openapi.yaml
-├── plugins/                    # Custom services
-│   └── MyService.swift
-└── aro.yaml
+└── plugins/
+    └── MyService.swift
+```
+
+**Package Plugin (with dependencies):**
+```
+MyApp/
+├── main.aro
+├── openapi.yaml
+└── plugins/
+    └── MyPlugin/
+        ├── Package.swift
+        └── Sources/MyPlugin/
+            └── MyService.swift
 ```
 
 ### Writing a Plugin
 
+Plugins use a C-compatible JSON interface:
+
 ```swift
-// plugins/MyService.swift
+// plugins/GreetingService.swift
 import Foundation
 
-@_cdecl("aro_plugin_register")
-public func register(_ registry: UnsafeMutableRawPointer) {
-    let reg = AROPluginRegistry(registry)
-    reg.registerService("myservice", MyService())
+/// Plugin initialization - returns service metadata as JSON
+@_cdecl("aro_plugin_init")
+public func pluginInit() -> UnsafePointer<CChar> {
+    let metadata = """
+    {"services": [{"name": "greeting", "symbol": "greeting_call"}]}
+    """
+    return UnsafePointer(strdup(metadata)!)
 }
 
-struct MyService: AROPluginService {
-    func call(_ method: String, args: [String: Any]) throws -> Any {
-        switch method {
-        case "greet":
-            let name = args["name"] as? String ?? "World"
-            return "Hello, \(name)!"
-        default:
-            throw NSError(domain: "Plugin", code: 1)
-        }
+/// Service entry point - C-callable interface
+@_cdecl("greeting_call")
+public func greetingCall(
+    _ methodPtr: UnsafePointer<CChar>,
+    _ argsPtr: UnsafePointer<CChar>,
+    _ resultPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+) -> Int32 {
+    let method = String(cString: methodPtr)
+    let argsJSON = String(cString: argsPtr)
+
+    // Parse arguments
+    var args: [String: Any] = [:]
+    if let data = argsJSON.data(using: .utf8),
+       let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        args = parsed
     }
+
+    // Execute method
+    let name = args["name"] as? String ?? "World"
+    let result: String
+
+    switch method.lowercased() {
+    case "hello":
+        result = "Hello, \(name)!"
+    case "goodbye":
+        result = "Goodbye, \(name)!"
+    default:
+        let errorJSON = "{\"error\": \"Unknown method: \(method)\"}"
+        resultPtr.pointee = strdup(errorJSON)
+        return 1
+    }
+
+    // Return result as JSON
+    let resultJSON = "{\"result\": \"\(result)\"}"
+    resultPtr.pointee = strdup(resultJSON)
+    return 0
 }
 ```
 
-### Plugin Configuration
+### Package Plugin with Dependencies
 
-```yaml
-# aro.yaml
-plugins:
-  - source: plugins/MyService.swift
-  - source: plugins/CacheService.swift
+For plugins that need external libraries, use a Swift package:
 
-  # Pre-compiled plugins
-  - library: /path/to/CustomPlugin.dylib
+```swift
+// plugins/ZipPlugin/Package.swift
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "ZipPlugin",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "ZipPlugin", type: .dynamic, targets: ["ZipPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.0")
+    ],
+    targets: [
+        .target(name: "ZipPlugin", dependencies: ["Zip"])
+    ]
+)
 ```
 
 ### How Plugins Work
 
 1. ARO scans `./plugins/` directory
-2. Compiles `.swift` files to `.dylib` using `swiftc`
-3. Loads via `dlopen`
-4. Calls `aro_plugin_register` entry point
+2. For `.swift` files: compiles to `.dylib` using `swiftc`
+3. For directories with `Package.swift`: builds using `swift build`
+4. Loads dynamic library via `dlopen`
+5. Calls `aro_plugin_init` to get service metadata (JSON)
+6. Registers each service with the symbol from metadata
 
 Compiled plugins are cached in `.aro-cache/` and only recompiled when source changes.
+
+### Plugin Metadata Format
+
+The `aro_plugin_init` function returns JSON:
+
+```json
+{
+  "services": [
+    {"name": "greeting", "symbol": "greeting_call"}
+  ]
+}
+```
+
+- `name`: Service name used in ARO code (`<greeting: hello>`)
+- `symbol`: C function symbol to call
 
 ### Using Plugin Services
 

--- a/Examples/ZipService/content/file1.txt
+++ b/Examples/ZipService/content/file1.txt
@@ -1,0 +1,2 @@
+Hello from file 1!
+This is a test file for the ARO Zip plugin demo.

--- a/Examples/ZipService/content/file2.txt
+++ b/Examples/ZipService/content/file2.txt
@@ -1,0 +1,2 @@
+Hello from file 2!
+This is another test file for the ARO Zip plugin demo.

--- a/Examples/ZipService/main.aro
+++ b/Examples/ZipService/main.aro
@@ -1,0 +1,21 @@
+(* ZipService - Demonstrates using a plugin with external dependencies *)
+
+(Application-Start: Zip Service Demo) {
+    <Log> the <message> for the <console> with "Testing zip plugin...".
+
+    (* Zip the files in content folder *)
+    <Call> the <result> from the <zip: compress> with {
+        files: ["Examples/ZipService/content/file1.txt", "Examples/ZipService/content/file2.txt"],
+        output: "Examples/ZipService/content/archive.zip"
+    }.
+
+    <Log> the <message> for the <console> with "Zip result:".
+    <Log> the <message> for the <console> with <result>.
+
+    <Return> an <OK: status> for the <startup>.
+}
+
+(Application-End: Success) {
+    <Log> the <message> for the <console> with "Zip service demo completed.".
+    <Return> an <OK: status> for the <shutdown>.
+}

--- a/Examples/ZipService/plugins/ZipPlugin/Package.resolved
+++ b/Examples/ZipService/plugins/ZipPlugin/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "zip",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marmelroy/Zip.git",
+      "state" : {
+        "revision" : "67fa55813b9e7b3b9acee9c0ae501def28746d76",
+        "version" : "2.1.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Examples/ZipService/plugins/ZipPlugin/Package.swift
+++ b/Examples/ZipService/plugins/ZipPlugin/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "ZipPlugin",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "ZipPlugin", type: .dynamic, targets: ["ZipPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.0")
+    ],
+    targets: [
+        .target(
+            name: "ZipPlugin",
+            dependencies: ["Zip"]
+        )
+    ]
+)

--- a/Examples/ZipService/plugins/ZipPlugin/Sources/ZipPlugin/ZipService.swift
+++ b/Examples/ZipService/plugins/ZipPlugin/Sources/ZipPlugin/ZipService.swift
@@ -1,0 +1,211 @@
+// ============================================================
+// ZipService.swift
+// ARO Plugin - Zip file compression using marmelroy/Zip library
+// ============================================================
+//
+// This plugin demonstrates using external Swift Package dependencies
+// in ARO plugins. It provides file compression capabilities.
+//
+// Usage in ARO:
+//   <Call> the <result> from the <zip: compress> with {
+//       files: ["file1.txt", "file2.txt"],
+//       output: "archive.zip"
+//   }.
+
+import Foundation
+import Zip
+
+// MARK: - Plugin Initialization
+
+/// Plugin initialization - returns service metadata as JSON
+/// This tells ARO what services and symbols this plugin provides
+@_cdecl("aro_plugin_init")
+public func pluginInit() -> UnsafePointer<CChar> {
+    let metadata = """
+    {"services": [{"name": "zip", "symbol": "zip_call"}]}
+    """
+    let cstr = strdup(metadata)!
+    return UnsafePointer(cstr)
+}
+
+// MARK: - Service Implementation
+
+/// Main entry point for the zip service
+/// - Parameters:
+///   - methodPtr: Method name (C string)
+///   - argsPtr: Arguments as JSON (C string)
+///   - resultPtr: Output - result as JSON (caller must free)
+/// - Returns: 0 for success, non-zero for error
+@_cdecl("zip_call")
+public func zipCall(
+    _ methodPtr: UnsafePointer<CChar>,
+    _ argsPtr: UnsafePointer<CChar>,
+    _ resultPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+) -> Int32 {
+    let method = String(cString: methodPtr)
+    let argsJSON = String(cString: argsPtr)
+
+    // Parse arguments
+    var args: [String: Any] = [:]
+    if let data = argsJSON.data(using: .utf8),
+       let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        args = parsed
+    }
+
+    // Execute method
+    do {
+        let result = try executeMethod(method, args: args)
+        let resultJSON = try encodeResult(result)
+        resultPtr.pointee = resultJSON.withCString { strdup($0) }
+        return 0
+    } catch {
+        // Return error message
+        let errorJSON = "{\"error\": \"\(escapeJSON(String(describing: error)))\"}"
+        resultPtr.pointee = errorJSON.withCString { strdup($0) }
+        return 1
+    }
+}
+
+/// Execute a zip method
+private func executeMethod(_ method: String, args: [String: Any]) throws -> [String: Any] {
+    switch method.lowercased() {
+    case "compress", "zip":
+        return try compress(args: args)
+
+    case "decompress", "unzip":
+        return try decompress(args: args)
+
+    case "list":
+        return try listContents(args: args)
+
+    default:
+        throw ZipPluginError.unknownMethod(method)
+    }
+}
+
+/// Compress files into a zip archive
+private func compress(args: [String: Any]) throws -> [String: Any] {
+    guard let files = args["files"] as? [String] else {
+        throw ZipPluginError.missingArgument("files")
+    }
+
+    guard let outputPath = args["output"] as? String else {
+        throw ZipPluginError.missingArgument("output")
+    }
+
+    // Convert to URLs
+    let fileURLs = files.map { URL(fileURLWithPath: $0) }
+    let outputURL = URL(fileURLWithPath: outputPath)
+
+    // Verify all input files exist
+    for fileURL in fileURLs {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw ZipPluginError.fileNotFound(fileURL.path)
+        }
+    }
+
+    // Create zip archive
+    try Zip.zipFiles(paths: fileURLs, zipFilePath: outputURL, password: nil, progress: nil)
+
+    return [
+        "success": true,
+        "output": outputPath,
+        "filesCompressed": files.count
+    ]
+}
+
+/// Decompress a zip archive
+private func decompress(args: [String: Any]) throws -> [String: Any] {
+    guard let archivePath = args["archive"] as? String else {
+        throw ZipPluginError.missingArgument("archive")
+    }
+
+    let destination = args["destination"] as? String ?? "."
+
+    let archiveURL = URL(fileURLWithPath: archivePath)
+    let destinationURL = URL(fileURLWithPath: destination)
+
+    guard FileManager.default.fileExists(atPath: archiveURL.path) else {
+        throw ZipPluginError.fileNotFound(archivePath)
+    }
+
+    // Extract archive
+    try Zip.unzipFile(archiveURL, destination: destinationURL, overwrite: true, password: nil)
+
+    return [
+        "success": true,
+        "destination": destination
+    ]
+}
+
+/// List contents of a zip archive
+private func listContents(args: [String: Any]) throws -> [String: Any] {
+    guard let archivePath = args["archive"] as? String else {
+        throw ZipPluginError.missingArgument("archive")
+    }
+
+    let archiveURL = URL(fileURLWithPath: archivePath)
+
+    guard FileManager.default.fileExists(atPath: archiveURL.path) else {
+        throw ZipPluginError.fileNotFound(archivePath)
+    }
+
+    // Get file list - unzip to temp to list
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    try Zip.unzipFile(archiveURL, destination: tempDir, overwrite: true, password: nil)
+
+    // List extracted files
+    var files: [String] = []
+    if let enumerator = FileManager.default.enumerator(at: tempDir, includingPropertiesForKeys: nil) {
+        while let fileURL = enumerator.nextObject() as? URL {
+            let relativePath = fileURL.path.replacingOccurrences(of: tempDir.path + "/", with: "")
+            files.append(relativePath)
+        }
+    }
+
+    return [
+        "archive": archivePath,
+        "files": files
+    ]
+}
+
+/// Encode result as JSON string
+private func encodeResult(_ result: [String: Any]) throws -> String {
+    let data = try JSONSerialization.data(withJSONObject: result)
+    return String(data: data, encoding: .utf8) ?? "{}"
+}
+
+/// Escape string for JSON
+private func escapeJSON(_ string: String) -> String {
+    return string
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\t", with: "\\t")
+}
+
+// MARK: - Errors
+
+/// Plugin-specific errors
+enum ZipPluginError: Error, CustomStringConvertible {
+    case unknownMethod(String)
+    case missingArgument(String)
+    case fileNotFound(String)
+
+    var description: String {
+        switch self {
+        case .unknownMethod(let method):
+            return "Unknown method: \(method). Available: compress, decompress, list"
+        case .missingArgument(let arg):
+            return "Missing required argument: \(arg)"
+        case .fileNotFound(let path):
+            return "File not found: \(path)"
+        }
+    }
+}

--- a/Website/src/docs.html
+++ b/Website/src/docs.html
@@ -424,6 +424,16 @@
                     <span class="doc-card-link">Browse proposals →</span>
                 </a>
 
+                <a href="docs/services.html" class="doc-card">
+                    <div class="doc-card-icon">&#x1F50C;</div>
+                    <h3>External Services</h3>
+                    <p>
+                        Integrate with external APIs and libraries using the Call action.
+                        Create custom service plugins.
+                    </p>
+                    <span class="doc-card-link">Learn services →</span>
+                </a>
+
                 <a href="docs/action-developer-guide.html" class="doc-card">
                     <div class="doc-card-icon">&#x1F527;</div>
                     <h3>Creating Custom Actions</h3>

--- a/Website/src/docs/language-proposals.html
+++ b/Website/src/docs/language-proposals.html
@@ -176,7 +176,7 @@
                 <tr>
                     <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0016-interoperability.md" class="proposal-link">ARO-0016</a></td>
                     <td>Interoperability</td>
-                    <td><span class="status-draft">Draft</span></td>
+                    <td><span class="status-implemented">Implemented</span></td>
                 </tr>
                 <tr>
                     <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0018-query-language.md" class="proposal-link">ARO-0018</a></td>

--- a/Website/src/docs/services.html
+++ b/Website/src/docs/services.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>External Services - ARO Programming Language</title>
+{{head}}
+    <style>
+        .doc-page { padding: 120px 24px 80px; max-width: 900px; margin: 0 auto; }
+        .doc-header { margin-bottom: 48px; }
+        .doc-header h1 { font-size: clamp(2rem, 5vw, 3rem); font-weight: 700; margin-bottom: 16px; letter-spacing: -0.02em; }
+        .doc-header .lead { font-size: 1.25rem; color: var(--color-text-muted); line-height: 1.7; }
+        .doc-page h2 { font-size: 1.8rem; font-weight: 600; margin: 48px 0 16px; padding-top: 24px; border-top: 1px solid rgba(255, 255, 255, 0.1); }
+        .doc-page h3 { font-size: 1.3rem; font-weight: 600; margin: 32px 0 12px; color: var(--color-secondary); }
+        .doc-page p { font-size: 1.1rem; color: var(--color-text-muted); line-height: 1.8; margin-bottom: 16px; }
+        .doc-page code { font-family: var(--font-mono); background: var(--color-bg-alt); padding: 3px 8px; border-radius: 4px; font-size: 0.9rem; color: var(--color-secondary); }
+        .doc-page pre { background: var(--color-bg-alt); border-radius: var(--radius-md); padding: 24px; overflow-x: auto; margin: 24px 0; border: 1px solid rgba(255, 255, 255, 0.1); }
+        .doc-page pre code { background: none; padding: 0; font-size: 0.9rem; line-height: 1.7; color: var(--color-text); }
+        .doc-page ul, .doc-page ol { color: var(--color-text-muted); margin: 16px 0 16px 24px; line-height: 1.8; }
+        .doc-page li { margin-bottom: 8px; }
+        .doc-page strong { color: var(--color-text); }
+        .doc-page table { width: 100%; border-collapse: collapse; margin: 24px 0; }
+        .doc-page th, .doc-page td { padding: 12px 16px; text-align: left; border: 1px solid rgba(255, 255, 255, 0.1); }
+        .doc-page th { background: var(--color-bg-alt); font-weight: 600; color: var(--color-text); }
+        .doc-page td { color: var(--color-text-muted); }
+        .highlight-box { background: rgba(124, 58, 237, 0.1); border: 1px solid rgba(124, 58, 237, 0.3); border-radius: var(--radius-md); padding: 24px; margin: 32px 0; }
+        .highlight-box h4 { color: var(--color-primary); font-size: 1.1rem; margin-bottom: 12px; }
+        .highlight-box p { margin-bottom: 0; }
+        .back-link { display: inline-flex; align-items: center; gap: 8px; color: var(--color-text-muted); text-decoration: none; font-size: 0.95rem; margin-bottom: 24px; transition: color 0.2s; }
+        .back-link:hover { color: var(--color-primary); }
+        .code-comment { color: #6b7280; }
+        .code-keyword { color: #7c3aed; font-weight: 600; }
+        .code-string { color: #10b981; }
+        .code-feature { color: #f472b6; }
+        .code-result { color: #06b6d4; }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav-content">
+            <a href="/aro/" class="logo"><span class="logo-aro">ARO</span></a>
+            <div class="nav-links">
+                <a href="../fdd.html">The FDD Story</a>
+                <a href="../getting-started.html">Get Started</a>
+                <a href="../docs.html" style="color: var(--color-text);">Docs</a>
+                <a href="../disclaimer.html">Motivation</a>
+                <a href="../download.html">Download</a>
+                <a href="https://github.com/KrisSimon/aro" class="nav-github">
+                    <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                    <span class="github-stars">
+                        <svg viewBox="0 0 16 16"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
+                        <span class="github-stars-count"></span>
+                    </span>
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="doc-page">
+        <a href="../docs.html" class="back-link">&#x2190; Back to Documentation</a>
+
+        <header class="doc-header">
+            <h1 class="gradient-text">External Services</h1>
+            <p class="lead">
+                ARO integrates with external libraries and APIs through Services. This chapter covers
+                the Call action, built-in services, and creating custom plugins.
+            </p>
+        </header>
+
+        <div class="highlight-box">
+            <h4>One Action, Many Services</h4>
+            <p>
+                All external integrations use the same pattern: <code>&lt;Call&gt; the &lt;result&gt; from the &lt;service: method&gt; with { args }</code>.
+                HTTP APIs, databases, file processors - they all work the same way.
+            </p>
+        </div>
+
+        <h2>The Call Action</h2>
+
+        <h3>Syntax</h3>
+        <pre><code><span class="code-keyword">&lt;Call&gt;</span> the <span class="code-result">&lt;result&gt;</span> from the &lt;service: method&gt; with { key: value, ... }.</code></pre>
+
+        <table>
+            <thead>
+                <tr><th>Component</th><th>Description</th></tr>
+            </thead>
+            <tbody>
+                <tr><td><code>result</code></td><td>Variable to store the result</td></tr>
+                <tr><td><code>service</code></td><td>Service name (e.g., <code>http</code>, <code>postgres</code>, <code>zip</code>)</td></tr>
+                <tr><td><code>method</code></td><td>Method to invoke (e.g., <code>get</code>, <code>query</code>, <code>compress</code>)</td></tr>
+                <tr><td><code>args</code></td><td>Key-value arguments passed to the method</td></tr>
+            </tbody>
+        </table>
+
+        <h2>Built-in HTTP Service</h2>
+
+        <p>The <code>http</code> service is built-in and provides HTTP client capabilities.</p>
+
+        <h3>GET Request</h3>
+        <pre><code><span class="code-keyword">&lt;Call&gt;</span> the <span class="code-result">&lt;response&gt;</span> from the &lt;http: get&gt; with {
+    url: <span class="code-string">"https://api.example.com/users"</span>
+}.</code></pre>
+
+        <h3>GET with Headers</h3>
+        <pre><code><span class="code-keyword">&lt;Call&gt;</span> the <span class="code-result">&lt;response&gt;</span> from the &lt;http: get&gt; with {
+    url: <span class="code-string">"https://api.example.com/protected"</span>,
+    headers: { <span class="code-string">"Authorization"</span>: <span class="code-string">"Bearer token123"</span> }
+}.</code></pre>
+
+        <h3>POST Request</h3>
+        <pre><code><span class="code-keyword">&lt;Call&gt;</span> the <span class="code-result">&lt;response&gt;</span> from the &lt;http: post&gt; with {
+    url: <span class="code-string">"https://api.example.com/users"</span>,
+    body: { name: <span class="code-string">"Alice"</span>, email: <span class="code-string">"alice@example.com"</span> },
+    headers: { <span class="code-string">"Content-Type"</span>: <span class="code-string">"application/json"</span> }
+}.</code></pre>
+
+        <h3>HTTP Methods Reference</h3>
+        <table>
+            <thead>
+                <tr><th>Method</th><th>Arguments</th><th>Description</th></tr>
+            </thead>
+            <tbody>
+                <tr><td><code>get</code></td><td><code>url</code>, <code>headers?</code></td><td>HTTP GET request</td></tr>
+                <tr><td><code>post</code></td><td><code>url</code>, <code>body</code>, <code>headers?</code></td><td>HTTP POST request</td></tr>
+                <tr><td><code>put</code></td><td><code>url</code>, <code>body</code>, <code>headers?</code></td><td>HTTP PUT request</td></tr>
+                <tr><td><code>patch</code></td><td><code>url</code>, <code>body</code>, <code>headers?</code></td><td>HTTP PATCH request</td></tr>
+                <tr><td><code>delete</code></td><td><code>url</code>, <code>headers?</code></td><td>HTTP DELETE request</td></tr>
+            </tbody>
+        </table>
+
+        <h3>Response Format</h3>
+        <pre><code>{
+    <span class="code-string">"status"</span>: 200,
+    <span class="code-string">"headers"</span>: { <span class="code-string">"Content-Type"</span>: <span class="code-string">"application/json"</span> },
+    <span class="code-string">"body"</span>: { ... }
+}</code></pre>
+
+        <h2>Plugin System</h2>
+
+        <p>Add custom services via plugins. Plugins can be single Swift files or Swift packages with dependencies.</p>
+
+        <h3>Plugin Structure</h3>
+        <p><strong>Simple Plugin (single file):</strong></p>
+        <pre><code>MyApp/
+├── main.aro
+└── plugins/
+    └── GreetingService.swift</code></pre>
+
+        <p><strong>Package Plugin (with dependencies):</strong></p>
+        <pre><code>MyApp/
+├── main.aro
+└── plugins/
+    └── ZipPlugin/
+        ├── Package.swift
+        └── Sources/ZipPlugin/
+            └── ZipService.swift</code></pre>
+
+        <h3>Writing a Plugin</h3>
+        <p>Plugins use a C-compatible JSON interface:</p>
+
+        <pre><code><span class="code-comment">// plugins/GreetingService.swift</span>
+import Foundation
+
+<span class="code-comment">/// Plugin initialization - returns service metadata as JSON</span>
+@_cdecl(<span class="code-string">"aro_plugin_init"</span>)
+public func pluginInit() -> UnsafePointer&lt;CChar&gt; {
+    let metadata = <span class="code-string">"""
+    {"services": [{"name": "greeting", "symbol": "greeting_call"}]}
+    """</span>
+    return UnsafePointer(strdup(metadata)!)
+}
+
+<span class="code-comment">/// Service entry point - C-callable interface</span>
+@_cdecl(<span class="code-string">"greeting_call"</span>)
+public func greetingCall(
+    _ methodPtr: UnsafePointer&lt;CChar&gt;,
+    _ argsPtr: UnsafePointer&lt;CChar&gt;,
+    _ resultPtr: UnsafeMutablePointer&lt;UnsafeMutablePointer&lt;CChar&gt;?&gt;
+) -> Int32 {
+    let method = String(cString: methodPtr)
+    let argsJSON = String(cString: argsPtr)
+
+    <span class="code-comment">// Parse arguments from JSON</span>
+    var args: [String: Any] = [:]
+    if let data = argsJSON.data(using: .utf8),
+       let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        args = parsed
+    }
+
+    <span class="code-comment">// Execute method</span>
+    let name = args[<span class="code-string">"name"</span>] as? String ?? <span class="code-string">"World"</span>
+    let result = <span class="code-string">"Hello, \(name)!"</span>
+
+    <span class="code-comment">// Return result as JSON</span>
+    let resultJSON = <span class="code-string">"{\"result\": \"\(result)\"}"</span>
+    resultPtr.pointee = strdup(resultJSON)
+    return 0  <span class="code-comment">// 0 = success</span>
+}</code></pre>
+
+        <h3>Package Plugin with Dependencies</h3>
+        <p>For plugins that need external libraries (e.g., Zip, databases):</p>
+
+        <pre><code><span class="code-comment">// plugins/ZipPlugin/Package.swift</span>
+<span class="code-comment">// swift-tools-version:5.9</span>
+import PackageDescription
+
+let package = Package(
+    name: <span class="code-string">"ZipPlugin"</span>,
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: <span class="code-string">"ZipPlugin"</span>, type: .dynamic, targets: [<span class="code-string">"ZipPlugin"</span>])
+    ],
+    dependencies: [
+        .package(url: <span class="code-string">"https://github.com/marmelroy/Zip.git"</span>, from: <span class="code-string">"2.1.0"</span>)
+    ],
+    targets: [
+        .target(name: <span class="code-string">"ZipPlugin"</span>, dependencies: [<span class="code-string">"Zip"</span>])
+    ]
+)</code></pre>
+
+        <h3>Using Plugin Services</h3>
+        <pre><code><span class="code-feature">(Application-Start: Plugin Demo)</span> {
+    <span class="code-keyword">&lt;Call&gt;</span> the <span class="code-result">&lt;greeting&gt;</span> from the &lt;greeting: hello&gt; with {
+        name: <span class="code-string">"ARO Developer"</span>
+    }.
+
+    <span class="code-keyword">&lt;Log&gt;</span> the <span class="code-result">&lt;message&gt;</span> for the &lt;console&gt; with &lt;greeting&gt;.
+    <span class="code-keyword">&lt;Return&gt;</span> an <span class="code-result">&lt;OK: status&gt;</span> for the &lt;startup&gt;.
+}</code></pre>
+
+        <h3>How Plugins Work</h3>
+        <ol>
+            <li>ARO scans <code>./plugins/</code> directory</li>
+            <li>For <code>.swift</code> files: compiles to <code>.dylib</code> using <code>swiftc</code></li>
+            <li>For directories with <code>Package.swift</code>: builds using <code>swift build</code></li>
+            <li>Loads dynamic library via <code>dlopen</code></li>
+            <li>Calls <code>aro_plugin_init</code> to get service metadata (JSON)</li>
+            <li>Registers each service with the symbol from metadata</li>
+        </ol>
+        <p>Compiled plugins are cached in <code>.aro-cache/</code> and only recompiled when source changes.</p>
+
+        <h2>Creating Custom Services (Swift)</h2>
+
+        <p>For compiled ARO applications, you can register services directly in Swift:</p>
+
+        <pre><code>public struct PostgresService: AROService {
+    public static let name = <span class="code-string">"postgres"</span>
+
+    public init() throws { <span class="code-comment">/* connection setup */</span> }
+
+    public func call(_ method: String, args: [String: any Sendable]) async throws -> any Sendable {
+        switch method {
+        case <span class="code-string">"query"</span>:
+            let sql = args[<span class="code-string">"sql"</span>] as! String
+            return try await executeQuery(sql)
+        default:
+            throw ServiceError.unknownMethod(method, service: Self.name)
+        }
+    }
+}
+
+<span class="code-comment">// Register at startup</span>
+try ExternalServiceRegistry.shared.register(PostgresService())</code></pre>
+
+        <div class="highlight-box">
+            <h4>Next Steps</h4>
+            <p>
+                <a href="http-services.html">HTTP Services</a> - Built-in HTTP server<br>
+                <a href="action-developer-guide.html">Creating Custom Actions</a> - Extend ARO with new actions
+            </p>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p>Sometime this page should build with ARO. Obviously.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add support for Swift Package plugins with external dependencies in PluginLoader
- Create ZipService example demonstrating the marmelroy/Zip library integration
- Update ARO-0016 proposal to match actual JSON-based plugin implementation
- Update Services.md documentation with correct plugin interface
- Create new services.html documentation page on website
- Fix ARO-0016 status on website (Draft → Implemented)

## Changes

### Plugin System Enhancement
- `PluginLoader.swift` now detects subdirectories with `Package.swift`
- Builds package plugins using `swift build -c release` instead of direct `swiftc`
- Loads the built `.dylib` from `.build/release/`

### ZipService Example
- New `Examples/ZipService/` demonstrating external dependency usage
- Uses marmelroy/Zip library for file compression
- Includes test files in `content/` folder

### Documentation Fixes
- Fixed plugin interface docs (was wrong `@_cdecl("aro_plugin_register")`, now correct `@_cdecl("aro_plugin_init")`)
- Added Package.swift plugin documentation

## Test plan

- [x] Build ARO: `swift build`
- [x] Run ZipService example: `.build/debug/aro run ./Examples/ZipService`
- [x] Verify `archive.zip` is created with both test files

Closes #17