### PR TITLE
feat(runtime): omit feature set prefix in compiled binary output

### DIFF
--- a/Book/TheLanguageGuide/Chapter18-NativeCompilation.md
+++ b/Book/TheLanguageGuide/Chapter18-NativeCompilation.md
@@ -104,7 +104,33 @@ Logging becomes more important when detailed runtime output is not available. In
 
 ---
 
-## 17.8 Development Workflow
+## 17.8 Output Formatting
+
+Native binaries produce cleaner output than interpreted execution. This difference is intentional and reflects the different contexts in which each mode is used.
+
+When running with the interpreter using `aro run`, log messages include a feature set name prefix:
+
+```
+[Application-Start] Starting server...
+[Application-Start] Server ready on port 8080
+[listUsers] Processing request...
+```
+
+When running a compiled binary, the same log messages appear without the prefix:
+
+```
+Starting server...
+Server ready on port 8080
+Processing request...
+```
+
+The interpreter's prefix identifies which feature set produced each message. This visibility aids debugging during development—when something goes wrong, you can see exactly where messages originated. The prefix becomes unnecessary noise in production, where the focus shifts from debugging to clean operation.
+
+Response formatting remains unchanged between modes. The `[OK]` status prefix and response data appear identically in both cases, providing consistent machine-parseable output for scripts and monitoring tools.
+
+---
+
+## 17.9 Development Workflow
 
 Development typically uses interpreted execution for rapid iteration. The interpreted mode has faster turnaround—you change code and immediately run the updated version without a compile step. Verbose output shows what the runtime does, aiding debugging and understanding.
 
@@ -116,7 +142,7 @@ Release processes should produce native binaries with release optimizations. Tag
 
 ---
 
-## 17.9 Limitations
+## 17.10 Limitations
 
 Native compilation has limitations compared to interpreted execution.
 
@@ -130,7 +156,7 @@ The compilation step adds time to the development cycle. For rapid iteration, th
 
 ---
 
-## 17.10 Best Practices
+## 17.11 Best Practices
 
 Use interpreted mode during development for fast iteration and detailed diagnostics. Switch to native compilation for deployment testing and release.
 

--- a/Documentation/LanguageGuide/ApplicationLifecycle.md
+++ b/Documentation/LanguageGuide/ApplicationLifecycle.md
@@ -184,6 +184,28 @@ aro run ./MyApp
 
 The application runs and exits when Application-Start completes.
 
+### Output Differences: Interpreter vs Compiled
+
+When running with the interpreter (`aro run`), log messages include a feature set name prefix for debugging visibility:
+
+```
+[Application-Start] Starting server...
+[Application-Start] Server ready on port 8080
+[OK] startup
+```
+
+When running a compiled binary (`aro build`), log messages are clean without the prefix:
+
+```
+Starting server...
+Server ready on port 8080
+[OK] startup
+```
+
+This difference is intentional:
+- **Interpreter mode**: The prefix helps identify which feature set produced each log message during development and debugging
+- **Compiled mode**: Clean output is more appropriate for production deployment
+
 ### Keeping Applications Alive
 
 For servers that should run indefinitely, use the `<Keepalive>` action:

--- a/Sources/ARORuntime/Actions/BuiltIn/ResponseActions.swift
+++ b/Sources/ARORuntime/Actions/BuiltIn/ResponseActions.swift
@@ -374,7 +374,12 @@ public struct LogAction: ActionImplementation {
             formattedMessage = "{\"level\":\"info\",\"source\":\"\(context.featureSetName)\",\"message\":\"\(message.replacingOccurrences(of: "\"", with: "\\\""))\"}"
         case .human:
             // Readable format for CLI/console
-            formattedMessage = "[\(context.featureSetName)] \(message)"
+            // Compiled binaries get clean output without feature set prefix
+            if context.isCompiled {
+                formattedMessage = message
+            } else {
+                formattedMessage = "[\(context.featureSetName)] \(message)"
+            }
         case .developer:
             // Diagnostic format for testing/debugging
             formattedMessage = "LOG[\(target)] \(context.featureSetName): \(message)"

--- a/Sources/ARORuntime/Bridge/RuntimeBridge.swift
+++ b/Sources/ARORuntime/Bridge/RuntimeBridge.swift
@@ -51,7 +51,7 @@ final class AROCContextHandle {
 
     init(runtime: AROCRuntimeHandle, featureSetName: String) {
         self.runtime = runtime
-        self.context = RuntimeContext(featureSetName: featureSetName)
+        self.context = RuntimeContext(featureSetName: featureSetName, isCompiled: true)
     }
 }
 

--- a/Sources/ARORuntime/Core/ExecutionContext.swift
+++ b/Sources/ARORuntime/Core/ExecutionContext.swift
@@ -234,6 +234,9 @@ public protocol ExecutionContext: AnyObject, Sendable {
 
     /// Whether execution is in test mode
     var isTestMode: Bool { get }
+
+    /// Whether execution is from a compiled binary (vs interpreter)
+    var isCompiled: Bool { get }
 }
 
 // MARK: - Default Implementations
@@ -245,4 +248,7 @@ public extension ExecutionContext {
         }
         return value
     }
+
+    /// Default: not compiled (interpreter mode)
+    var isCompiled: Bool { false }
 }

--- a/Sources/ARORuntime/Core/RuntimeContext.swift
+++ b/Sources/ARORuntime/Core/RuntimeContext.swift
@@ -39,6 +39,9 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
     /// Output context for formatting
     private let _outputContext: OutputContext
 
+    /// Whether this is a compiled binary execution
+    private let _isCompiled: Bool
+
     // MARK: - Metadata
 
     public let featureSetName: String
@@ -55,12 +58,14 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
     ///   - outputContext: Output context for formatting (defaults to .human)
     ///   - eventBus: Optional event bus for event emission
     ///   - parent: Optional parent context for nested execution
+    ///   - isCompiled: Whether this is a compiled binary execution (defaults to false)
     public init(
         featureSetName: String,
         businessActivity: String = "",
         outputContext: OutputContext = .human,
         eventBus: EventBus? = nil,
-        parent: ExecutionContext? = nil
+        parent: ExecutionContext? = nil,
+        isCompiled: Bool = false
     ) {
         self.featureSetName = featureSetName
         self.businessActivity = businessActivity
@@ -68,6 +73,7 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
         self._outputContext = outputContext
         self.eventBus = eventBus
         self.parent = parent
+        self._isCompiled = isCompiled
     }
 
     // MARK: - Variable Management
@@ -191,7 +197,8 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
             businessActivity: businessActivity,
             outputContext: _outputContext,
             eventBus: eventBus,
-            parent: self
+            parent: self,
+            isCompiled: _isCompiled
         )
     }
 
@@ -202,7 +209,8 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
             businessActivity: businessActivity,
             outputContext: _outputContext,
             eventBus: eventBus,
-            parent: self
+            parent: self,
+            isCompiled: _isCompiled
         )
     }
 
@@ -250,6 +258,10 @@ public final class RuntimeContext: ExecutionContext, @unchecked Sendable {
 
     public var isTestMode: Bool {
         _outputContext == .developer
+    }
+
+    public var isCompiled: Bool {
+        _isCompiled
     }
 }
 


### PR DESCRIPTION
## Summary

- Compiled binaries now produce cleaner log output without the `[FeatureSetName]` prefix
- Interpreter mode (`aro run`) retains the prefix for debugging visibility
- Response formatting (`[OK]` status) remains unchanged in both modes

**Interpreter output:**
```
[Application-Start] Starting server...
[Application-Start] Server ready
[OK] startup
```

**Compiled binary output:**
```
Starting server...
Server ready
[OK] startup
```

## Test plan

- [x] Build project: `swift build`
- [x] Verify interpreter shows prefix: `.build/debug/aro run ./Examples/Computations`
- [x] Build compiled example: `.build/debug/aro build ./Examples/Computations`
- [x] Verify compiled binary omits prefix: `./Examples/Computations/Computations`
- [x] Verify `[OK]` response format unchanged in both modes