### PR TITLE
fix(windows): enable file operations on Windows

### DIFF
--- a/Sources/ARORuntime/Actions/ActionRegistry.swift
+++ b/Sources/ARORuntime/Actions/ActionRegistry.swift
@@ -89,8 +89,7 @@ public final class ActionRegistry: @unchecked Sendable {
         // File actions
         register(WatchAction.self)
 
-        // File operations (ARO-0036) - not available on Windows
-        #if !os(Windows)
+        // File operations (ARO-0036)
         register(ListAction.self)
         register(StatAction.self)
         register(ExistsAction.self)
@@ -98,7 +97,6 @@ public final class ActionRegistry: @unchecked Sendable {
         register(CopyAction.self)
         register(MoveAction.self)
         register(AppendAction.self)
-        #endif
 
         // Wait action for long-running applications
         register(WaitForEventsAction.self)

--- a/Sources/ARORuntime/Actions/BuiltIn/FileActions.swift
+++ b/Sources/ARORuntime/Actions/BuiltIn/FileActions.swift
@@ -4,8 +4,6 @@
 // ARO-0036: Native File and Directory Operations
 // ============================================================
 
-#if !os(Windows)
-
 import Foundation
 import AROParser
 
@@ -476,5 +474,3 @@ public struct AppendResult: Sendable, Equatable {
     public let path: String
     public let success: Bool
 }
-
-#endif  // !os(Windows)


### PR DESCRIPTION
## Summary
- Refactor FileSystemService.swift to separate platform-agnostic types from platform-specific implementations
- Move FileInfo, FileSystemError, and file events outside `#if !os(Windows)`
- Create Windows-compatible AROFileSystemService without FileMonitor
- Remove Windows conditionals from FileActions.swift and ActionRegistry.swift

## Windows Support
This enables the following file operations on Windows:
- List (directory contents)
- Stat (file metadata)
- Exists (file/directory existence check)
- CreateDirectory
- Copy
- Move
- Append

The **Watch** action remains unavailable on Windows as it requires FileMonitor.

## Test plan
- [x] macOS build passes
- [x] All 601 tests pass locally
- [ ] Windows CI build passes
- [ ] Linux CI build passes