### PR TITLE
feat(actions): establish verb synonym guidelines

### DIFF
--- a/Proposals/ARO-0036-native-file-operations.md
+++ b/Proposals/ARO-0036-native-file-operations.md
@@ -129,18 +129,21 @@ Returns a boolean: `true` if the path exists and matches the expected type (file
 
 ---
 
-## 4. CreateDirectory Action
+## 4. Make Action
 
-Create a directory with all intermediate directories.
+Create a file or directory at the specified path.
 
-**Verbs:** `createdirectory`, `mkdir`, `make`
+**Verbs:** `make` (canonical), `touch`, `createdirectory`, `mkdir`
 **Prepositions:** `at`, `to`, `for`
 
 ```aro
-(* Natural syntax with "make" verb *)
+(* Create a directory *)
 <Make> the <directory> at the <path: "./output/reports/2024">.
 
-(* Traditional syntax *)
+(* Create or touch a file *)
+<Touch> the <file> at the <path: "./logs/app.log">.
+
+(* Legacy syntax still works *)
 <CreateDirectory> the <output-dir> at the <path: "./output/reports/2024">.
 
 (* Check and create *)
@@ -151,8 +154,10 @@ Create a directory with all intermediate directories.
 
 ### Behavior
 
-- Creates all intermediate directories (like `mkdir -p`)
-- Succeeds silently if directory already exists
+- When result is `<directory>`: Creates all intermediate directories (like `mkdir -p`)
+- When result is `<file>`: Creates empty file or updates modification time (like `touch`)
+- Succeeds silently if path already exists
+- Creates parent directories automatically
 - Runtime error on permission failure
 
 ---

--- a/Sources/ARORuntime/Actions/ActionRegistry.swift
+++ b/Sources/ARORuntime/Actions/ActionRegistry.swift
@@ -92,7 +92,7 @@ public final class ActionRegistry: @unchecked Sendable {
         register(ListAction.self)
         register(StatAction.self)
         register(ExistsAction.self)
-        register(CreateDirectoryAction.self)
+        register(MakeAction.self)
         register(CopyAction.self)
         register(MoveAction.self)
         register(AppendAction.self)
@@ -117,8 +117,8 @@ public final class ActionRegistry: @unchecked Sendable {
         // External service actions (ARO-0016)
         register(CallAction.self)
 
-        // System exec action (ARO-0033)
-        register(ExecAction.self)
+        // System execute action (ARO-0033)
+        register(ExecuteAction.self)
     }
 
     /// Register a custom action

--- a/Sources/ARORuntime/Actions/BuiltIn/CallAction.swift
+++ b/Sources/ARORuntime/Actions/BuiltIn/CallAction.swift
@@ -39,7 +39,7 @@ import AROParser
 /// ```
 public struct CallAction: ActionImplementation {
     public static let role: ActionRole = .request
-    public static let verbs: Set<String> = ["call", "invoke", "execute"]
+    public static let verbs: Set<String> = ["call", "invoke"]
     public static let validPrepositions: Set<Preposition> = [.from, .with, .via]
 
     public init() {}

--- a/Sources/ARORuntime/Actions/BuiltIn/ExecAction.swift
+++ b/Sources/ARORuntime/Actions/BuiltIn/ExecAction.swift
@@ -1,5 +1,5 @@
 // ============================================================
-// ExecAction.swift
+// ExecuteAction.swift
 // ARO Runtime - System Command Execution Action (ARO-0033)
 // ============================================================
 
@@ -109,27 +109,27 @@ public struct ExecConfig: Sendable {
     }
 }
 
-// MARK: - Exec Action
+// MARK: - Execute Action
 
 /// Executes shell commands on the host system
 ///
-/// The Exec action runs shell commands and returns structured results with
+/// The Execute action runs shell commands and returns structured results with
 /// error status, message, output, and exit code. Results are formatted
 /// according to the execution context (JSON for HTTP, plaintext for console).
 ///
 /// ## Syntax
 /// ```aro
 /// (* Simple command *)
-/// <Exec> the <result> for the <command> with "ls -la".
+/// <Execute> the <result> for the <command> with "ls -la".
 ///
 /// (* With working directory *)
-/// <Exec> the <result> on the <system> with {
+/// <Execute> the <result> on the <system> with {
 ///     command: "npm install",
 ///     workingDirectory: "/app"
 /// }.
 ///
 /// (* With timeout and environment *)
-/// <Exec> the <result> for the <build> with {
+/// <Execute> the <result> for the <build> with {
 ///     command: "make release",
 ///     environment: { CC: "clang" },
 ///     timeout: 60000
@@ -146,9 +146,15 @@ public struct ExecConfig: Sendable {
 ///     command: String     // Executed command
 /// }
 /// ```
-public struct ExecAction: ActionImplementation {
+///
+/// ## Verbs
+/// - `execute` (canonical)
+/// - `exec` (synonym)
+/// - `shell` (synonym)
+/// - `run-command` (synonym)
+public struct ExecuteAction: ActionImplementation {
     public static let role: ActionRole = .request
-    public static let verbs: Set<String> = ["exec", "shell"]
+    public static let verbs: Set<String> = ["execute", "exec", "shell", "run-command"]
     public static let validPrepositions: Set<Preposition> = [.on, .with, .for]
 
     public init() {}

--- a/Sources/ARORuntime/Actions/BuiltIn/ExtractAction.swift
+++ b/Sources/ARORuntime/Actions/BuiltIn/ExtractAction.swift
@@ -601,6 +601,7 @@ public protocol FileSystemService: Sendable {
     func list(directory: String, pattern: String?, recursive: Bool) async throws -> [FileInfo]
     func existsWithType(path: String) -> (exists: Bool, isDirectory: Bool)
     func createDirectory(path: String) async throws
+    func touch(path: String) async throws
     func copy(source: String, destination: String) async throws
     func move(source: String, destination: String) async throws
     func append(path: String, content: String) async throws

--- a/Sources/ARORuntime/FileSystem/FileSystemService.swift
+++ b/Sources/ARORuntime/FileSystem/FileSystemService.swift
@@ -330,6 +330,25 @@ public final class AROFileSystemService: FileSystemService, FileMonitorService, 
         }
     }
 
+    /// Touch a file (create or update modification time)
+    public func touch(path: String) async throws {
+        let url = URL(fileURLWithPath: path)
+
+        // Create parent directory if needed
+        let parentDir = url.deletingLastPathComponent().path
+        if !fileManager.fileExists(atPath: parentDir) {
+            try fileManager.createDirectory(atPath: parentDir, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        if fileManager.fileExists(atPath: path) {
+            // Update modification time
+            try fileManager.setAttributes([.modificationDate: Date()], ofItemAtPath: path)
+        } else {
+            // Create empty file
+            fileManager.createFile(atPath: path, contents: nil, attributes: nil)
+        }
+    }
+
     // MARK: - ARO-0036: Extended File Operations
 
     /// Get file or directory stats
@@ -757,6 +776,25 @@ public final class AROFileSystemService: FileSystemService, @unchecked Sendable 
             try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
         } catch {
             throw FileSystemError.createDirectoryError(path, error.localizedDescription)
+        }
+    }
+
+    /// Touch a file (create or update modification time)
+    public func touch(path: String) async throws {
+        let url = URL(fileURLWithPath: path)
+
+        // Create parent directory if needed
+        let parentDir = url.deletingLastPathComponent().path
+        if !fileManager.fileExists(atPath: parentDir) {
+            try fileManager.createDirectory(atPath: parentDir, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        if fileManager.fileExists(atPath: path) {
+            // Update modification time
+            try fileManager.setAttributes([.modificationDate: Date()], ofItemAtPath: path)
+        } else {
+            // Create empty file
+            fileManager.createFile(atPath: path, contents: nil, attributes: nil)
         }
     }
 

--- a/Tests/AROuntimeTests/ComputeActionTests.swift
+++ b/Tests/AROuntimeTests/ComputeActionTests.swift
@@ -452,7 +452,7 @@ struct CreateActionTests {
         #expect(CreateAction.verbs.contains("create"))
         #expect(CreateAction.verbs.contains("build"))
         #expect(CreateAction.verbs.contains("construct"))
-        // Note: "make" verb moved to CreateDirectoryAction for filesystem operations
+        // Note: "make" verb moved to MakeAction for filesystem operations
     }
 
     @Test("Create returns source value")

--- a/Tests/AROuntimeTests/FileActionsTests.swift
+++ b/Tests/AROuntimeTests/FileActionsTests.swift
@@ -73,28 +73,29 @@ struct ExistsActionTests {
     }
 }
 
-// MARK: - CreateDirectory Action Tests
+// MARK: - Make Action Tests
 
-@Suite("CreateDirectory Action Tests")
-struct CreateDirectoryActionTests {
+@Suite("Make Action Tests")
+struct MakeActionTests {
 
-    @Test("CreateDirectory action role is own")
-    func testCreateDirectoryActionRole() {
-        #expect(CreateDirectoryAction.role == .own)
+    @Test("Make action role is own")
+    func testMakeActionRole() {
+        #expect(MakeAction.role == .own)
     }
 
-    @Test("CreateDirectory action verbs")
-    func testCreateDirectoryActionVerbs() {
-        #expect(CreateDirectoryAction.verbs.contains("createdirectory"))
-        #expect(CreateDirectoryAction.verbs.contains("mkdir"))
-        #expect(CreateDirectoryAction.verbs.contains("make"))
+    @Test("Make action verbs - make is canonical")
+    func testMakeActionVerbs() {
+        #expect(MakeAction.verbs.contains("make"))
+        #expect(MakeAction.verbs.contains("touch"))
+        #expect(MakeAction.verbs.contains("createdirectory"))
+        #expect(MakeAction.verbs.contains("mkdir"))
     }
 
-    @Test("CreateDirectory action valid prepositions")
-    func testCreateDirectoryActionPrepositions() {
-        #expect(CreateDirectoryAction.validPrepositions.contains(.to))
-        #expect(CreateDirectoryAction.validPrepositions.contains(.for))
-        #expect(CreateDirectoryAction.validPrepositions.contains(.at))
+    @Test("Make action valid prepositions")
+    func testMakeActionPrepositions() {
+        #expect(MakeAction.validPrepositions.contains(.to))
+        #expect(MakeAction.validPrepositions.contains(.for))
+        #expect(MakeAction.validPrepositions.contains(.at))
     }
 }
 
@@ -168,11 +169,20 @@ struct AppendActionTests {
 @Suite("File Action Result Types")
 struct FileActionResultTypeTests {
 
-    @Test("CreateDirectoryResult creation")
-    func testCreateDirectoryResult() {
-        let result = CreateDirectoryResult(path: "/test/dir", success: true)
+    @Test("MakeResult creation for directory")
+    func testMakeResultDirectory() {
+        let result = MakeResult(path: "/test/dir", success: true, isFile: false)
         #expect(result.path == "/test/dir")
         #expect(result.success == true)
+        #expect(result.isFile == false)
+    }
+
+    @Test("MakeResult creation for file")
+    func testMakeResultFile() {
+        let result = MakeResult(path: "/test/file.txt", success: true, isFile: true)
+        #expect(result.path == "/test/file.txt")
+        #expect(result.success == true)
+        #expect(result.isFile == true)
     }
 
     @Test("CopyResult creation")


### PR DESCRIPTION
## Summary

Implements the verb synonym guidelines discussed in #78:

- **Rename `ExecAction` → `ExecuteAction`**: `execute` is now the canonical verb, with `exec`, `shell`, `run-command` as synonyms
- **Rename `CreateDirectoryAction` → `MakeAction`**: `make` is now the canonical verb, with `touch`, `createdirectory`, `mkdir` as synonyms
- **Remove `execute` from `CallAction`**: Resolves verb conflict between function calls and shell execution
- **Add `touch` functionality**: MakeAction can now create files (when result is `<file>`) or directories

### Guidelines Established

1. **Primary verb = Action class name** (e.g., `MakeAction`, `ExecuteAction`)
2. **Primary verb = Documentation canonical**
3. **Add synonyms when**: natural phrasing differs significantly, unambiguous, commonly used

### Corrected Verb Synonyms

| Primary Verb | Synonyms | Proposal |
|--------------|----------|----------|
| `Retrieve` | `Get`, `Fetch`, `Load`, `Find` | ARO-0009 |
| `Store` | `Save`, `Persist` | ARO-0009 |
| `Throw` | `Raise`, `Fail` | ARO-0009 |
| `Make` | `Touch`, `CreateDirectory`, `Mkdir` | ARO-0036 |
| `Execute` | `Exec`, `Shell`, `Run-Command` | ARO-0033 |

### Files Changed

- `Sources/ARORuntime/Actions/BuiltIn/ExecAction.swift` - Renamed struct to ExecuteAction
- `Sources/ARORuntime/Actions/BuiltIn/CallAction.swift` - Removed 'execute' verb
- `Sources/ARORuntime/Actions/BuiltIn/FileActions.swift` - Renamed struct to MakeAction, added touch
- `Sources/ARORuntime/Actions/BuiltIn/ExtractAction.swift` - Added touch to FileSystemService protocol
- `Sources/ARORuntime/FileSystem/FileSystemService.swift` - Implemented touch method
- `Sources/ARORuntime/Actions/ActionRegistry.swift` - Updated registrations
- `Proposals/ARO-0033-system-exec-action.md` - Updated to show Execute as primary
- `Proposals/ARO-0036-native-file-operations.md` - Updated to show Make as primary
- `Tests/AROuntimeTests/FileActionsTests.swift` - Updated tests
- `Tests/AROuntimeTests/ComputeActionTests.swift` - Updated comment

## Test plan

- [x] `swift build` - compiles successfully
- [x] `swift test --filter FileActionsTests` - 26 tests pass

Closes #78