### PR TITLE
feat(ARO-0038): list element access with :first/:last/ranges/picks

### DIFF
--- a/Book/TheLanguageGuide/AppendixA-ActionReference.md
+++ b/Book/TheLanguageGuide/AppendixA-ActionReference.md
@@ -80,6 +80,7 @@ Pulls data from a structured source.
 **Syntax:**
 ```aro
 <Extract> the <result> from the <source: property>.
+<Extract> the <result: specifier> from the <list>.
 ```
 
 **Examples:**
@@ -90,6 +91,35 @@ Pulls data from a structured source.
 <Extract> the <email> from the <user: email>.
 <Extract> the <order> from the <event: order>.
 ```
+
+**List Element Access (ARO-0038):**
+
+Extract specific elements from arrays using result specifiers:
+
+```aro
+(* Keywords *)
+<Extract> the <item: first> from the <list>.
+<Extract> the <item: last> from the <list>.
+
+(* Numeric index: 0 = last, 1 = second-to-last *)
+<Extract> the <item: 0> from the <list>.
+<Extract> the <item: 1> from the <list>.
+
+(* Range: elements 2, 3, 4, 5 *)
+<Extract> the <subset: 2-5> from the <list>.
+
+(* Pick: elements at indices 0, 3, 7 *)
+<Extract> the <selection: 0,3,7> from the <list>.
+```
+
+| Specifier | Returns |
+|-----------|---------|
+| `first` | First element |
+| `last` | Last element |
+| `0` | Last element (reverse indexing) |
+| `n` | Element at (count - 1 - n) |
+| `2-5` | Array of elements |
+| `0,3,7` | Array of elements |
 
 **Valid Prepositions:** `from`
 

--- a/Examples/DirectoryReplicator/main.aro
+++ b/Examples/DirectoryReplicator/main.aro
@@ -1,0 +1,33 @@
+(* DirectoryReplicator - Replicates directory structure from template *)
+(* Reads ../template and creates matching empty directories in current location *)
+(* Uses ARO-0038 list element access to extract relative paths from Split results *)
+
+(Application-Start: Directory Replicator) {
+    (* Define template source path *)
+    <Create> the <template-path> with "../template".
+
+    <Log> the <start> for the <console> with "Scanning template directory...".
+
+    (* List all entries recursively from template - use specifier for recursive *)
+    <List> the <all-entries: recursively> from the <directory: template-path>.
+
+    (* Process each directory entry *)
+    for each <entry> in <all-entries> where <entry: isDirectory> is true {
+        (* Extract the full path *)
+        <Extract> the <full-path> from the <entry: path>.
+
+        (* Split to remove template/ prefix from absolute path *)
+        <Split> the <path-parts> from the <full-path> by /template\//.
+
+        (* ARO-0038: Get the last element (relative path) using result specifier *)
+        <Extract> the <relative-path: last> from the <path-parts>.
+
+        (* Create the directory in current location *)
+        <Make> the <created> to the <path: relative-path>.
+
+        <Log> the <status> for the <console> with <relative-path>.
+    }
+
+    <Log> the <done> for the <console> with "Directory structure replicated.".
+    <Return> an <OK: status> for the <replication>.
+}

--- a/Proposals/ARO-0038-list-element-access.md
+++ b/Proposals/ARO-0038-list-element-access.md
@@ -1,0 +1,216 @@
+# ARO-0038: List Element Access
+
+* Proposal: ARO-0038
+* Author: ARO Language Team
+* Status: **Implemented**
+* Requires: ARO-0032
+
+## Abstract
+
+This proposal extends the element access semantics from repositories (ARO-0032) to all Lists (arrays) in ARO. It enables accessing individual elements, ranges, and selections from any array using specifiers on the result descriptor.
+
+## Motivation
+
+ARO-0032 introduced powerful element access for repositories:
+```aro
+<Retrieve> the <item: last> from the <user-repository>.
+<Retrieve> the <item: first> from the <user-repository>.
+<Retrieve> the <item: 0> from the <user-repository>.
+```
+
+However, this syntax only works with repositories. When working with arrays from other sources (Split results, Create literals, computed collections), developers cannot use the same intuitive syntax:
+
+```aro
+(* Split returns an array, but we can't easily access elements *)
+<Split> the <parts> from the <csv-line> by /,/.
+(* No way to get just the last part! *)
+```
+
+This proposal extends element access to ALL lists, making ARO more consistent and powerful.
+
+---
+
+## 1. Element Access Syntax
+
+Element access uses specifiers on the **result** descriptor (left side), not the object:
+
+```aro
+<Extract> the <result: specifier> from the <source>.
+```
+
+### 1.1 Keyword Access
+
+| Specifier | Description | Example |
+|-----------|-------------|---------|
+| `first` | First element (oldest) | `<Extract> the <item: first> from the <list>.` |
+| `last` | Last element (most recent) | `<Extract> the <item: last> from the <list>.` |
+
+### 1.2 Numeric Index Access
+
+Indices follow the ARO-0032 convention where 0 = last element (most recent):
+
+| Index | Element |
+|-------|---------|
+| 0 | Last (most recent) |
+| 1 | Second-to-last |
+| 2 | Third-to-last |
+| n | (count - 1 - n)th element |
+
+```aro
+<Extract> the <item: 0> from the <list>.   (* last element *)
+<Extract> the <item: 1> from the <list>.   (* second-to-last *)
+```
+
+### 1.3 Range Access
+
+Extract consecutive elements using `start-end` syntax:
+
+```aro
+<Extract> the <subset: 2-5> from the <list>.   (* elements 2, 3, 4, 5 *)
+```
+
+Returns an array of elements at the specified indices.
+
+### 1.4 Pick Access
+
+Extract specific elements by listing indices separated by commas:
+
+```aro
+<Extract> the <selection: 0,3,7> from the <list>.   (* elements at 0, 3, 7 *)
+```
+
+Returns an array of elements at the specified indices.
+
+---
+
+## 2. Examples
+
+### Basic Element Access
+
+```aro
+(* Create a list *)
+<Create> the <fruits> with ["apple", "banana", "cherry", "date", "elderberry"].
+
+(* Access by keyword *)
+<Extract> the <first-fruit: first> from the <fruits>.   (* "apple" *)
+<Extract> the <last-fruit: last> from the <fruits>.     (* "elderberry" *)
+
+(* Access by index (0 = last) *)
+<Extract> the <recent: 0> from the <fruits>.    (* "elderberry" *)
+<Extract> the <second: 1> from the <fruits>.    (* "date" *)
+```
+
+### Split String and Access Parts
+
+```aro
+(* Split CSV line *)
+<Create> the <csv-line> with "name,email,phone,address".
+<Split> the <fields> from the <csv-line> by /,/.
+
+(* Access specific fields *)
+<Extract> the <name: first> from the <fields>.      (* "name" *)
+<Extract> the <address: last> from the <fields>.    (* "address" *)
+<Extract> the <email: 2> from the <fields>.         (* second-to-last = "phone" *)
+```
+
+### Range Access
+
+```aro
+<Create> the <numbers> with [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].
+
+(* Extract range *)
+<Extract> the <middle: 3-6> from the <numbers>.   (* [7, 6, 5, 4] in reverse order *)
+```
+
+### Pick Access
+
+```aro
+<Create> the <letters> with ["a", "b", "c", "d", "e", "f", "g"].
+
+(* Pick specific elements *)
+<Extract> the <vowels: 0,2,4> from the <letters>.   (* ["g", "e", "c"] *)
+```
+
+---
+
+## 3. Indexing Semantics
+
+Following ARO-0032, all indices are **reverse-indexed** where 0 = last element:
+
+```
+Array: [A, B, C, D, E]
+Index:  4  3  2  1  0
+        ↑           ↑
+      first       last
+```
+
+| Specifier | Maps to Array Index |
+|-----------|---------------------|
+| `first` | 0 (first element) |
+| `last` | count - 1 (last element) |
+| `0` | count - 1 (last element) |
+| `1` | count - 2 |
+| `n` | count - 1 - n |
+
+This semantic aligns with the "most recent first" paradigm used in repositories, where index 0 always refers to the most recently added item.
+
+---
+
+## 4. Return Values
+
+| Access Type | Returns |
+|-------------|---------|
+| Single element (first, last, numeric) | Single value or empty string if out of bounds |
+| Range (3-5) | Array of elements |
+| Pick (3,5,7) | Array of elements |
+
+Out-of-bounds indices are silently ignored (return empty string for single access, skip in range/pick).
+
+---
+
+## 5. Implementation
+
+The implementation requires updating `ExtractAction` to check `result.specifiers` when the source is an array:
+
+```swift
+if let array = source as? [any Sendable] {
+    if let specifier = result.specifiers.first {
+        switch specifier.lowercased() {
+        case "last": return array.last ?? ""
+        case "first": return array.first ?? ""
+        default:
+            // Handle range (3-5), pick (3,5,7), or single index
+        }
+    }
+    return array  // No specifier = full array
+}
+```
+
+---
+
+## 6. Compatibility
+
+This proposal:
+- Extends existing repository semantics to all arrays
+- Does not change existing behavior
+- Uses result specifiers consistently with ARO-0032
+- Maintains backward compatibility with existing Extract usage
+
+---
+
+## 7. Alternatives Considered
+
+### 7.1 Object-side Specifiers
+```aro
+<Extract> the <item> from the <list: last>.  (* rejected *)
+```
+Rejected because ARO-0032 established result-side specifiers for element access.
+
+### 7.2 Separate Action
+```aro
+<Get> the <item> at <index> from the <list>.  (* rejected *)
+```
+Rejected as it introduces unnecessary action proliferation.
+
+### 7.3 Forward Indexing (0 = first)
+Rejected to maintain consistency with ARO-0032's "most recent first" paradigm.

--- a/Tests/AROuntimeTests/ExtractActionTests.swift
+++ b/Tests/AROuntimeTests/ExtractActionTests.swift
@@ -190,6 +190,127 @@ struct ExtractActionTests {
             #expect(error.localizedDescription.contains("nonexistent"))
         }
     }
+
+    // MARK: - ARO-0038: List Element Access Tests
+
+    @Test("Extract :first from array returns first element")
+    func testExtractFirstFromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["apple", "banana", "cherry"] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["first"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "apple")
+    }
+
+    @Test("Extract :last from array returns last element")
+    func testExtractLastFromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["apple", "banana", "cherry"] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["last"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "cherry")
+    }
+
+    @Test("Extract numeric index 0 returns last element (reverse indexing)")
+    func testExtractIndex0FromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["apple", "banana", "cherry"] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["0"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "cherry")
+    }
+
+    @Test("Extract numeric index 1 returns second-to-last element")
+    func testExtractIndex1FromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["apple", "banana", "cherry"] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["1"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "banana")
+    }
+
+    @Test("Extract range from array returns subset")
+    func testExtractRangeFromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["a", "b", "c", "d", "e"] as [any Sendable])
+
+        // Range 1-3 should return elements at reverse indices 1, 2, 3 = ["d", "c", "b"]
+        let (result, object) = createDescriptors(resultSpecifiers: ["1-3"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        let arr = value as? [any Sendable]
+        #expect(arr?.count == 3)
+        #expect(arr?[0] as? String == "d")
+        #expect(arr?[1] as? String == "c")
+        #expect(arr?[2] as? String == "b")
+    }
+
+    @Test("Extract pick from array returns specific elements")
+    func testExtractPickFromArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["a", "b", "c", "d", "e"] as [any Sendable])
+
+        // Pick 0,2,4 should return elements at reverse indices 0, 2, 4 = ["e", "c", "a"]
+        let (result, object) = createDescriptors(resultSpecifiers: ["0,2,4"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        let arr = value as? [any Sendable]
+        #expect(arr?.count == 3)
+        #expect(arr?[0] as? String == "e")
+        #expect(arr?[1] as? String == "c")
+        #expect(arr?[2] as? String == "a")
+    }
+
+    @Test("Extract :first from empty array returns empty string")
+    func testExtractFirstFromEmptyArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: [] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["first"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "")
+    }
+
+    @Test("Extract :last from empty array returns empty string")
+    func testExtractLastFromEmptyArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: [] as [any Sendable])
+
+        let (result, object) = createDescriptors(resultSpecifiers: ["last"], objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        #expect(value as? String == "")
+    }
+
+    @Test("Extract with no result specifier returns full array")
+    func testExtractNoSpecifierReturnsFullArray() async throws {
+        let action = ExtractAction()
+        let context = RuntimeContext(featureSetName: "Test")
+        context.bind("items", value: ["a", "b", "c"] as [any Sendable])
+
+        let (result, object) = createDescriptors(objectBase: "items")
+        let value = try await action.execute(result: result, object: object, context: context)
+
+        let arr = value as? [any Sendable]
+        #expect(arr?.count == 3)
+    }
 }
 
 // MARK: - Retrieve Action Tests


### PR DESCRIPTION
## Summary

- Implement list element access using result specifiers, extending ARO-0032 repository indexing semantics to all arrays
- Add `:first`/`:last` keywords, numeric indices, range syntax (`3-5`), and pick syntax (`0,3,7`)
- Create Examples/DirectoryReplicator demonstrating Split + Extract pattern

## Changes

| File | Change |
|------|--------|
| `Proposals/ARO-0038-list-element-access.md` | New proposal documenting the feature |
| `Sources/ARORuntime/Actions/BuiltIn/ExtractAction.swift` | Add `extractFromList()` method |
| `Tests/AROuntimeTests/ExtractActionTests.swift` | Add 9 new tests |
| `Book/TheLanguageGuide/AppendixA-ActionReference.md` | Update Extract action docs |
| `Examples/DirectoryReplicator/main.aro` | New example using the feature |

## Syntax Examples

```aro
(* Split and access elements *)
<Split> the <parts> from the <csv-line> by /,/.
<Extract> the <first-part: first> from the <parts>.
<Extract> the <last-part: last> from the <parts>.

(* Numeric index - 0 = last element per ARO-0032 *)
<Extract> the <item: 0> from the <list>.

(* Range - consecutive elements *)
<Extract> the <subset: 2-5> from the <list>.

(* Pick - specific elements *)
<Extract> the <selection: 0,3,7> from the <list>.
```

## Test plan

- [x] All 9 new tests pass
- [x] All 622 existing tests pass
- [x] Build succeeds