### PR TITLE
docs: fix documentation inconsistencies across proposals and book

### DIFF
--- a/Book/TheLanguageGuide/AppendixA-ActionReference.md
+++ b/Book/TheLanguageGuide/AppendixA-ActionReference.md
@@ -22,7 +22,7 @@ Complete reference for all built-in actions in ARO.
 | **Validate** | OWN | Check against rules | `<Validate> the <data> for the <schema>.` |
 | **Compare** | OWN | Compare values | `<Compare> the <hash> against the <stored>.` |
 | **Update** | OWN | Modify existing data | `<Update> the <user> with <changes>.` |
-| **CreateDirectory** | EXPORT | Create directory | `<CreateDirectory> the <dir> to the <path: "./out">.` |
+| **CreateDirectory** | OWN | Create directory | `<CreateDirectory> the <dir> to the <path: "./out">.` |
 | **Copy** | OWN | Copy file/directory | `<Copy> the <file: "./a.txt"> to the <destination: "./b.txt">.` |
 | **Move** | OWN | Move/rename file | `<Move> the <file: "./old.txt"> to the <destination: "./new.txt">.` |
 | **Map** | OWN | Transform collection elements | `<Map> the <names> from the <users: name>.` |
@@ -934,8 +934,9 @@ The `Keepalive` action blocks execution until a shutdown signal is received (SIG
 
 **Examples:**
 ```aro
-(Application-Start: My Server) {
-    <Start> the <http-server> on port 8080.
+(* HTTP server auto-starts when openapi.yaml is present *)
+(Application-Start: My API) {
+    <Log> the <startup: message> for the <console> with "API starting...".
     <Keepalive> the <application> for the <events>.
     <Return> an <OK: status> for the <startup>.
 }

--- a/Book/TheLanguageGuide/AppendixC-Grammar.md
+++ b/Book/TheLanguageGuide/AppendixC-Grammar.md
@@ -44,9 +44,8 @@ block = "{" , { statement } , "}" ;
 ```ebnf
 (* Statement types *)
 statement = aro_statement
+          | guarded_statement
           | publish_statement
-          | conditional_statement
-          | guard_statement
           | match_statement ;
 
 (* Core ARO statement: Action-Result-Object *)
@@ -55,11 +54,9 @@ aro_statement = action , [ article ] , result , preposition , [ article ] , obje
 (* Publish statement *)
 publish_statement = "<Publish>" , "as" , alias , variable , "." ;
 
-(* Conditional statements *)
-conditional_statement = "if" , condition , "then" , block , [ "else" , block ] ;
-
-(* Guard statements *)
-guard_statement = "when" , condition , block ;
+(* Guarded statement - ARO statement with conditional suffix *)
+guarded_statement = aro_statement_base , "when" , condition , "." ;
+aro_statement_base = action , [ article ] , result , preposition , [ article ] , object , [ modifiers ] ;
 
 (* Match statements *)
 match_statement = "match" , variable , "{" , { match_case } , [ default_case ] , "}" ;
@@ -290,7 +287,7 @@ The following identifiers are reserved:
 
 **Prepositions:** `from`, `to`, `for`, `with`, `into`, `against`, `via`, `on`, `as`
 
-**Control Flow:** `if`, `then`, `else`, `when`, `match`, `case`, `default`, `where`, `and`, `or`, `not`, `is`
+**Control Flow:** `when`, `match`, `case`, `default`, `otherwise`, `where`, `and`, `or`, `not`, `is`
 
 **Literals:** `true`, `false`, `empty`
 

--- a/Book/TheLanguageGuide/Chapter04-StatementAnatomy.md
+++ b/Book/TheLanguageGuide/Chapter04-StatementAnatomy.md
@@ -54,7 +54,7 @@ The distinction between results and objects is fundamental. Results are outputsâ
 
 ## 4.5 Prepositions: The Relationships Between Things
 
-Prepositions are small words that carry large meaning. In ARO, prepositions connect actions to their objects while communicating the nature of that connection. The language supports eight prepositions:
+Prepositions are small words that carry large meaning. In ARO, prepositions connect actions to their objects while communicating the nature of that connection. The language supports ten prepositions:
 
 | Preposition | Meaning | Common Actions |
 |-------------|---------|----------------|
@@ -65,7 +65,9 @@ Prepositions are small words that carry large meaning. In ARO, prepositions conn
 | `into` | Insertion | Store |
 | `against` | Comparison/validation | Validate, Compare |
 | `via` | Intermediate channel | Fetch (with proxy) |
-| `on` | Location/attachment | Start |
+| `on` | Location/attachment | Listen, Start |
+| `at` | Position/placement | CreateDirectory, Make |
+| `as` | Type annotation | Filter, Reduce, Map |
 
 Choosing the right preposition makes your code clearer and more accurate. When you extract a user identifier from the path parameters, "from" is the natural choice. When you create a user with provided data, "with" is the natural choice. When you store a user into a repository, "into" is the natural choice. Let the semantics of your operation guide your choice of preposition.
 

--- a/Book/TheLanguageGuide/Chapter07-Computations.md
+++ b/Book/TheLanguageGuide/Chapter07-Computations.md
@@ -60,7 +60,7 @@ ARO provides several built-in computations that cover common transformation need
 
 </div>
 
-The **length** operation counts elements—characters in strings, items in arrays, keys in dictionaries. The **uppercase** and **lowercase** operations transform case. The **hash** operation produces an integer hash value useful for comparisons.
+The **length** and **count** operations count elements—characters in strings, items in arrays, keys in dictionaries. While interchangeable for most purposes, `length` is typically used for strings and `count` for collections. The **uppercase** and **lowercase** operations transform case. The **hash** operation produces an integer hash value useful for comparisons.
 
 The **identity** operation, while seemingly trivial, serves an important purpose: it allows arithmetic expressions to be written naturally:
 

--- a/Book/TheLanguageGuide/Chapter08-QualifierSyntax.md
+++ b/Book/TheLanguageGuide/Chapter08-QualifierSyntax.md
@@ -55,7 +55,7 @@ Now `greeting-length` holds 12 and `farewell-length` holds 8. Both values exist 
 |--------|-----------|
 | **Compute** | `length`, `count`, `hash`, `uppercase`, `lowercase`, `identity` |
 | **Validate** | `required`, `exists`, `nonempty`, `email`, `numeric` |
-| **Transform** | `string`, `int`, `integer`, `float`, `bool`, `boolean`, `json` |
+| **Transform** | `string`, `int`, `integer`, `double`, `float`, `bool`, `boolean`, `json`, `identity` |
 | **Sort** | `ascending`, `descending` |
 
 ### Examples

--- a/Book/TheLanguageGuide/Chapter24-DataPipelines.md
+++ b/Book/TheLanguageGuide/Chapter24-DataPipelines.md
@@ -10,8 +10,22 @@ ARO supports four core data operations:
 |-----------|---------|---------|
 | **Fetch** | Retrieve and filter data | `<Fetch> the <users: List<User>> from the <repository>...` |
 | **Filter** | Filter existing collection | `<Filter> the <active: List<User>> from the <users>...` |
-| **Map** | Transform to different type | `<Map> the <summaries: List<UserSummary>> from the <users>.` |
-| **Reduce** | Aggregate to single value | `<Reduce> the <total: Float> from the <orders> with sum(<amount>).` |
+| **Map** | Transform to different type | `<Map> the <summaries> as List<UserSummary> from the <users>.` |
+| **Reduce** | Aggregate to single value | `<Reduce> the <total> as Float from the <orders> with sum(<amount>).` |
+
+### Type Annotation Syntax
+
+ARO supports two equivalent syntaxes for type annotations:
+
+```aro
+(* Colon syntax: type inside angle brackets *)
+<Filter> the <active-users: List<User>> from the <users> where <active> is true.
+
+(* As syntax: type follows the result descriptor *)
+<Filter> the <active-users> as List<User> from the <users> where <active> is true.
+```
+
+Both produce identical results. The `as Type` syntax (ARO-0038) can be more readable when the variable name is long, while the colon syntax keeps everything compact. Type annotations are optional since ARO infers types from the source collection.
 
 ---
 

--- a/Proposals/ARO-0024-sockets.md
+++ b/Proposals/ARO-0024-sockets.md
@@ -22,12 +22,12 @@ Applications often need real-time bidirectional communication:
 
 ### 1. Socket Server
 
-Start a TCP socket server using the `<Start>` action:
+Start a TCP socket server using the `<Listen>` action:
 
 ```aro
 (Application-Start: Echo Server) {
     <Log> the <message> for the <console> with "Starting socket server".
-    <Start> the <socket-server> on <port> with 9000.
+    <Listen> on port 9000 as <socket-server>.
     <Keepalive> the <application> for the <events>.
     <Return> an <OK: status> for the <startup>.
 }
@@ -66,8 +66,8 @@ public struct DataReceivedEvent: RuntimeEvent {
 }
 
 (Handle Data Received: Socket Event Handler) {
-    <Extract> the <data> from the <packet: buffer>.
-    <Extract> the <client> from the <packet: connection>.
+    <Extract> the <data> from the <event: data>.
+    <Extract> the <client> from the <event: connection>.
 
     (* Process received data *)
     <Transform> the <response> from the <data>.
@@ -75,7 +75,7 @@ public struct DataReceivedEvent: RuntimeEvent {
     (* Send response back *)
     <Send> the <response> to the <client>.
 
-    <Return> an <OK: status> for the <packet>.
+    <Return> an <OK: status> for the <event>.
 }
 
 (Handle Client Disconnected: Socket Event Handler) {
@@ -189,28 +189,28 @@ host_reference = "host:" , string_literal ;
 
 (Application-Start: Echo Socket) {
     <Log> the <message> for the <console> with "Starting echo socket on port 9000".
-    <Start> the <socket-server> on <port> with 9000.
+    <Listen> on port 9000 as <socket-server>.
     <Log> the <message> for the <console> with "Socket server listening on port 9000".
     <Keepalive> the <application> for the <events>.
     <Return> an <OK: status> for the <startup>.
 }
 
 (Handle Client Connected: Socket Event Handler) {
-    <Extract> the <client-id> from the <connection: id>.
-    <Extract> the <remote-address> from the <connection: remoteAddress>.
+    <Extract> the <client-id> from the <event: connectionId>.
+    <Extract> the <remote-address> from the <event: remoteAddress>.
     <Log> the <message> for the <console> with "Client connected".
     <Return> an <OK: status> for the <connection>.
 }
 
 (Handle Data Received: Socket Event Handler) {
-    <Extract> the <data> from the <packet: buffer>.
-    <Extract> the <client> from the <packet: connection>.
+    <Extract> the <data> from the <event: data>.
+    <Extract> the <client> from the <event: connection>.
 
     (* Echo back the received data *)
     <Send> the <data> to the <client>.
 
     <Log> the <message> for the <console> with "Echoed data back to client".
-    <Return> an <OK: status> for the <packet>.
+    <Return> an <OK: status> for the <event>.
 }
 
 (Handle Client Disconnected: Socket Event Handler) {

--- a/Proposals/ARO-0036-native-file-operations.md
+++ b/Proposals/ARO-0036-native-file-operations.md
@@ -29,16 +29,16 @@ List directory contents with optional pattern matching:
 
 ```aro
 (* List all entries *)
-<List> the <entries> in the <directory: "./uploads">.
+<List> the <entries> from the <directory: "./uploads">.
 
 (* List with glob pattern *)
-<List> the <aro-files> in the <directory: "./src"> matching "*.aro".
+<List> the <aro-files> from the <directory: "./src"> matching "*.aro".
 
 (* List recursively *)
-<List> the <all-files> in the <directory: "./project"> recursively.
+<List> the <all-files> from the <directory: "./project"> recursively.
 
 (* Combine pattern and recursive *)
-<List> the <sources> in the <directory: "./src"> matching "*.swift" recursively.
+<List> the <sources> from the <directory: "./src"> matching "*.swift" recursively.
 ```
 
 ### Result Structure
@@ -250,7 +250,7 @@ ARO normalizes paths for cross-platform compatibility:
     <Log> the <header> for the <console> with "=== Three Oldest Files ===".
 
     (* List all entries *)
-    <List> the <entries> in the <directory: ".">.
+    <List> the <entries> from the <directory: ".">.
 
     (* Filter to files only *)
     <Filter> the <files> from <entries> where <isFile> is true.
@@ -301,7 +301,7 @@ ARO normalizes paths for cross-platform compatibility:
         to the <destination: "./demo-output/hello-copy.txt">.
 
     (* List directory *)
-    <List> the <files> in the <directory: "./demo-output">.
+    <List> the <files> from the <directory: "./demo-output">.
 
     <ForEach> <file> in <files> {
         <Log> the <entry> for the <console> with "  - <file: name>".


### PR DESCRIPTION
## Summary

This PR resolves 21 documentation inconsistencies identified through a comprehensive review of proposals, wiki, and book documentation. The review compared all sources against the source of truth hierarchy: Proposals > Code > Wiki > Book.

### Changes by Priority

**CRITICAL fixes:**
- Remove non-existent `if-then-else` syntax from grammar docs
- Fix `when` clause syntax to use correct guarded statement suffix format
- ARO-0024: Align socket examples with `<Listen>` syntax and `<event: data>` extraction
- ARO-0012: Align emit syntax with ARO-0020 implementation (`<Emit> a <EventType: event>`)

**HIGH priority fixes:**
- Chapter13: Clarify HTTP server auto-starts when openapi.yaml is present (no explicit `<Start>` action needed)

**MEDIUM priority fixes:**
- AppendixA: Fix CreateDirectory role (EXPORT → OWN), update Keepalive example
- ARO-0036: Change List preposition from `in` to `from`
- Chapter04: Add `at` and `as` prepositions (now 10 total)
- Chapter07: Add `count` operation alongside `length`
- Chapter24: Add `as Type` syntax explanation (ARO-0038)

**LOW priority fixes:**
- Chapter08: Add `double` and `identity` to Transform operations
- Chapter13: Add OpenAPI file format precedence (yaml > yml > json)

### Files Modified

**Book (7 files):**
- AppendixA-ActionReference.md
- AppendixC-Grammar.md
- Chapter04-StatementAnatomy.md
- Chapter07-Computations.md
- Chapter08-QualifierSyntax.md
- Chapter13-OpenAPI.md
- Chapter24-DataPipelines.md

**Proposals (3 files):**
- ARO-0012-events-reactive.md
- ARO-0024-sockets.md
- ARO-0036-native-file-operations.md

**Wiki (separate commit to wiki repo):**
- Reference-Grammar.md
- Guide-HTTP-Services.md

## Test plan

- [ ] Verify grammar examples compile correctly
- [ ] Review all modified examples for syntax accuracy
- [ ] Check that proposals and book are now consistent