### PR TITLE
fix(website): repair broken links and add missing proposals

### DIFF
--- a/Website/build.js
+++ b/Website/build.js
@@ -69,7 +69,8 @@ const docsSubPages = [
     'http-services.html',
     'sockets.html',
     'services.html',
-    'file-operations.html'
+    'file-operations.html',
+    'ai-development-guide.html'
 ];
 docsSubPages.forEach(file => {
     processHtmlFile(`src/docs/${file}`, `dist/docs/${file}`, '../');

--- a/Website/dist/index.html
+++ b/Website/dist/index.html
@@ -249,7 +249,7 @@
                         <span class="feature-tag">Auto JSON parsing</span>
                         <span class="feature-tag">Response metadata</span>
                     </div>
-                    <a href="docs/guide/httpclient.html" class="example-link">Learn more &rarr;</a>
+                    <a href="docs/http-services.html" class="example-link">Learn more &rarr;</a>
                 </div>
             </div>
         </div>

--- a/Website/src/docs/language-proposals.html
+++ b/Website/src/docs/language-proposals.html
@@ -60,7 +60,7 @@
             <h1 class="gradient-text">Language Proposals</h1>
             <p class="lead">
                 The ARO evolution process is documented through numbered proposals that specify
-                every aspect of the language design. There are currently 37 proposals.
+                every aspect of the language design. There are currently 35 proposals.
             </p>
         </header>
 
@@ -258,6 +258,42 @@
                 <tr>
                     <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0029-native-file-monitoring.md" class="proposal-link">ARO-0029</a></td>
                     <td>Native File Monitoring</td>
+                    <td><span class="status-draft">Draft</span></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h2>Tooling and Extensions (ARO-0030 to ARO-0034)</h2>
+        <p>These proposals define IDE integration, repositories, and developer tooling.</p>
+
+        <table>
+            <thead>
+                <tr><th>Proposal</th><th>Title</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0030-ide-integration.md" class="proposal-link">ARO-0030</a></td>
+                    <td>IDE Integration</td>
+                    <td><span class="status-draft">Draft</span></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0031-context-aware-response-formatting.md" class="proposal-link">ARO-0031</a></td>
+                    <td>Context-Aware Response Formatting</td>
+                    <td><span class="status-implemented">Implemented</span></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0032-repositories.md" class="proposal-link">ARO-0032</a></td>
+                    <td>Repositories</td>
+                    <td><span class="status-implemented">Implemented</span></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0033-system-exec-action.md" class="proposal-link">ARO-0033</a></td>
+                    <td>System Exec Action</td>
+                    <td><span class="status-implemented">Implemented</span></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/KrisSimon/aro/blob/main/Proposals/ARO-0034-language-server-protocol.md" class="proposal-link">ARO-0034</a></td>
+                    <td>Language Server Protocol</td>
                     <td><span class="status-draft">Draft</span></td>
                 </tr>
             </tbody>

--- a/Website/src/index.html
+++ b/Website/src/index.html
@@ -215,7 +215,7 @@
                         <span class="feature-tag">Auto JSON parsing</span>
                         <span class="feature-tag">Response metadata</span>
                     </div>
-                    <a href="docs/guide/httpclient.html" class="example-link">Learn more &rarr;</a>
+                    <a href="docs/http-services.html" class="example-link">Learn more &rarr;</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Fix 404: Change `docs/guide/httpclient.html` to `docs/http-services.html` in index.html
- Fix build: Add `ai-development-guide.html` to docsSubPages array in build.js
- Add missing proposals ARO-0030 through ARO-0034 to language-proposals.html
- Update proposal count from 37 to 35 (ARO-0010 and ARO-0017 never existed)

## Test plan

- [x] Run `npm run build` in Website directory - builds successfully
- [x] Verify `dist/docs/` contains all 16 documentation pages including `ai-development-guide.html`
- [x] Verify index.html link points to `docs/http-services.html`