### PR TITLE
feat(cards): ARO promotional card generator

### DIFF
--- a/cards/.gitignore
+++ b/cards/.gitignore
@@ -1,0 +1,5 @@
+# Generated output
+output/
+
+# Dependencies
+node_modules/

--- a/cards/facts.yaml
+++ b/cards/facts.yaml
@@ -1,0 +1,911 @@
+# ARO 2026 Weekly Cards
+# Up to 5 cards per week (1-5) - max 260 cards
+# 1/2 = Core concept + syntax
+# 3/4/5 = Details, tables, additional examples
+
+facts:
+  # ===== WEEK 1: Core Pattern =====
+  - id: "01-1"
+    week: 1
+    day: 1
+    category: "Philosophy"
+    headline: "<Retrieve> the <user> from the <database>."
+    explanation: "ARO statements read like English sentences. Business stakeholders review code directly. No translation layer between requirements and implementation."
+
+  - id: "01-2"
+    week: 1
+    day: 2
+    category: "Syntax"
+    headline: "<Action> the <Result> from the <Object>."
+    explanation: "Every statement follows one pattern. Action = verb, Result = output, Object = input. Angle brackets mark identifiers. Period ends statements."
+
+  # ===== WEEK 2: Contract-First =====
+  - id: "02-1"
+    week: 2
+    day: 1
+    category: "Contract"
+    headline: "operationId: getUser"
+    explanation: "OpenAPI contract is required. No contract means no server. Teams agree on the API before writing code. Design-first eliminates integration surprises."
+
+  - id: "02-2"
+    week: 2
+    day: 2
+    category: "Contract"
+    headline: "(getUser: User API)"
+    explanation: "Feature set name matches operationId from openapi.yaml. Route wiring is automatic. No decorators, no routing config. Contract drives code."
+
+  # ===== WEEK 3: Return Status =====
+  - id: "03-1"
+    week: 3
+    day: 1
+    category: "Philosophy"
+    headline: "Write only the happy path"
+    explanation: "Write only the success path. Runtime handles all failures automatically. No try-catch blocks. No defensive programming. Ship features faster."
+
+  - id: "03-2"
+    week: 3
+    day: 2
+    category: "API"
+    headline: "<Return> an <OK: status> with <user>."
+    explanation: "Return ends execution with a status code. OK=200, Created=201, NotFound=404, BadRequest=400, Error=500. Status codes as English words."
+
+  - id: "03-3"
+    week: 3
+    day: 3
+    category: "API"
+    headline: "OK | Created | NotFound | BadRequest"
+    explanation: "OK=200, Created=201, Accepted=202, NoContent=204, BadRequest=400, Unauthorized=401, Forbidden=403, NotFound=404, Error=500."
+
+  # ===== WEEK 4: Events =====
+  - id: "04-1"
+    week: 4
+    day: 1
+    category: "Events"
+    headline: "<Emit> a <UserCreated: event> with <user>."
+    explanation: "Emit events without knowing who handles them. Add new handlers without touching existing code. Scale teams independently. True microservice thinking."
+
+  - id: "04-2"
+    week: 4
+    day: 2
+    category: "Events"
+    headline: "(Send Email: UserCreated Handler)"
+    explanation: "Handler suffix makes the feature set an event consumer. 'UserCreated' is the event name to handle. Multiple handlers per event supported."
+
+  # ===== WEEK 5: Feature Sets =====
+  - id: "05-1"
+    week: 5
+    day: 1
+    category: "Philosophy"
+    headline: "One pattern for all statements"
+    explanation: "Every ARO statement follows the same pattern. New team members read code immediately. Code reviews focus on logic, not style debates."
+
+  - id: "05-2"
+    week: 5
+    day: 2
+    category: "Syntax"
+    headline: "(Feature Name: Business Activity) { }"
+    explanation: "Feature sets group related statements. Name describes the business capability. Activity determines trigger: operationId, Handler, or Observer."
+
+  # ===== WEEK 6: Extract =====
+  - id: "06-1"
+    week: 6
+    day: 1
+    category: "Contract"
+    headline: "Schema validates before code runs"
+    explanation: "OpenAPI schemas define types. Requests validate automatically. Invalid data never reaches your code. Production errors drop dramatically."
+
+  - id: "06-2"
+    week: 6
+    day: 2
+    category: "Actions"
+    headline: "<Extract> the <id> from the <pathParameters: id>."
+    explanation: "Extract pulls data from sources. Colon navigates nested fields. Works with pathParameters, queryParameters, request:body, event:payload."
+
+  - id: "06-3"
+    week: 6
+    day: 3
+    category: "Actions"
+    headline: "<Extract> the <email> from the <request: body: user>."
+    explanation: "Colons chain to navigate deep structures. request:body:user:email gets the email from nested JSON. Schema validates the path exists."
+
+  # ===== WEEK 7: Compilation =====
+  - id: "07-1"
+    week: 7
+    day: 1
+    category: "Compiler"
+    headline: "aro build ./MyApp --optimize"
+    explanation: "Compile to native machine code via LLVM. No runtime installation needed. Copy one file, run anywhere. Container images shrink to megabytes."
+
+  - id: "07-2"
+    week: 7
+    day: 2
+    category: "Compiler"
+    headline: "aro run ./MyApp"
+    explanation: "run interprets immediately for development. build compiles to native binary for production. check validates syntax. Three modes for three needs."
+
+  - id: "07-3"
+    week: 7
+    day: 3
+    category: "Compiler"
+    headline: "aro check ./MyApp"
+    explanation: "Fast syntax validation without execution. Catches errors before runtime. Integrates with CI/CD pipelines. Zero dependencies to check."
+
+  # ===== WEEK 8: Error Messages =====
+  - id: "08-1"
+    week: 8
+    day: 1
+    category: "Philosophy"
+    headline: "Cannot retrieve the user from user-repo"
+    explanation: "When a statement fails, the statement itself becomes the error message. No separate error strings to maintain. Documentation stays in sync with code."
+
+  - id: "08-2"
+    week: 8
+    day: 2
+    category: "Data"
+    headline: "<Retrieve> the <user> from <user-repo> where id = <id>."
+    explanation: "where clause filters data. Natural language operators: is, is not, contains, starts with, ends with. Reads like a sentence."
+
+  # ===== WEEK 9: Multi-File =====
+  - id: "09-1"
+    week: 9
+    day: 1
+    category: "Philosophy"
+    headline: "No imports needed"
+    explanation: "All .aro files in a directory see each other automatically. No import statements. No module resolution. Add a file, it's available. Remove it, gone."
+
+  - id: "09-2"
+    week: 9
+    day: 2
+    category: "Syntax"
+    headline: "MyApp/main.aro + users.aro + events.aro"
+    explanation: "Organize by domain. Each file contains related feature sets. All auto-discovered at startup. Scale from one file to hundreds naturally."
+
+  # ===== WEEK 10: HTTP Server =====
+  - id: "10-1"
+    week: 10
+    day: 1
+    category: "HTTP"
+    headline: "<Start> the <http-server> on port 8080."
+    explanation: "SwiftNIO powers the HTTP server. Async, performant, battle-tested. One action starts it. Combine with Keepalive for long-running services."
+
+  - id: "10-2"
+    week: 10
+    day: 2
+    category: "HTTP"
+    headline: "<Keepalive> the <application>."
+    explanation: "Keepalive blocks execution until shutdown signal. Application continues processing events. SIGINT/SIGTERM trigger graceful shutdown."
+
+  # ===== WEEK 11: Handlers =====
+  - id: "11-1"
+    week: 11
+    day: 1
+    category: "Events"
+    headline: "(Log Activity: UserCreated Handler)"
+    explanation: "Name a feature set with Handler suffix. It automatically receives matching events. No subscription code. Convention over configuration."
+
+  - id: "11-2"
+    week: 11
+    day: 2
+    category: "Events"
+    headline: "<Extract> the <user> from the <event: payload>."
+    explanation: "Inside a handler, event:payload contains the emitted data. Access nested fields with colons. Type-safe access to event properties."
+
+  # ===== WEEK 12: Repositories =====
+  - id: "12-1"
+    week: 12
+    day: 1
+    category: "Data"
+    headline: "<Store> the <user> in the <user-repository>."
+    explanation: "Repositories store data in memory across requests. Perfect for prototypes and tests. Swap implementations later without changing code."
+
+  - id: "12-2"
+    week: 12
+    day: 2
+    category: "Data"
+    headline: "<Retrieve> the <users> from the <user-repository>."
+    explanation: "Retrieve reads stored data. Returns single item or collection. Add where clause to filter. Repository name must end with -repository."
+
+  - id: "12-3"
+    week: 12
+    day: 3
+    category: "Data"
+    headline: "<Update> the <user> in the <user-repository>."
+    explanation: "Update modifies existing records. Matches by id field. Triggers repository observers. Atomic operation within the repository."
+
+  - id: "12-4"
+    week: 12
+    day: 4
+    category: "Data"
+    headline: "<Delete> from the <user-repository> where id = <id>."
+    explanation: "Delete removes records matching the where clause. Triggers repository observers. Returns count of deleted items."
+
+  # ===== WEEK 13: Compute =====
+  - id: "13-1"
+    week: 13
+    day: 1
+    category: "Actions"
+    headline: "<Compute> the <hash> from the <password>."
+    explanation: "Hash passwords, count items, transform strings without external libraries. Every ARO installation has the same capabilities. Consistent everywhere."
+
+  - id: "13-2"
+    week: 13
+    day: 2
+    category: "Actions"
+    headline: "<Compute> the <total> from <price> * <quantity>."
+    explanation: "Compute transforms data. Supports arithmetic: + - * / %. Operations: length, count, uppercase, lowercase, hash. Result qualifier names the operation."
+
+  - id: "13-3"
+    week: 13
+    day: 3
+    category: "Actions"
+    headline: "<Compute> the <len: length> from the <text>."
+    explanation: "Qualifier specifies the operation. length counts characters. count counts items in lists. uppercase/lowercase transforms case. hash creates secure hash."
+
+  # ===== WEEK 14: Articles =====
+  - id: "14-1"
+    week: 14
+    day: 1
+    category: "Syntax"
+    headline: "<Extract> the <user> from the <request>."
+    explanation: "Articles (a, an, the) make code read like requirements documents. Auditors understand what the code does. Regulatory compliance simplified."
+
+  - id: "14-2"
+    week: 14
+    day: 2
+    category: "Syntax"
+    headline: "a <new: user> | an <error> | the <result>"
+    explanation: "Articles are optional but improve readability. 'a' for new items, 'an' before vowels, 'the' for existing. Use what reads best."
+
+  # ===== WEEK 15: Lifecycle =====
+  - id: "15-1"
+    week: 15
+    day: 1
+    category: "Lifecycle"
+    headline: "(Application-Start: My App)"
+    explanation: "Exactly one Application-Start per app. Compiler enforces this. Start services, load config, initialize state. Entry point for execution."
+
+  - id: "15-2"
+    week: 15
+    day: 2
+    category: "Lifecycle"
+    headline: "(Application-End: Success)"
+    explanation: "Optional shutdown handler. Success triggered by SIGTERM/SIGINT. Stop services, flush buffers, log final state. Graceful shutdown."
+
+  - id: "15-3"
+    week: 15
+    day: 3
+    category: "Lifecycle"
+    headline: "(Application-End: Error)"
+    explanation: "Optional error handler. Triggered by unhandled failures. Log error details, notify monitoring. At most one Success and one Error handler per app."
+
+  # ===== WEEK 16: Request Body =====
+  - id: "16-1"
+    week: 16
+    day: 1
+    category: "API"
+    headline: "<Extract> the <data> from the <request: body>."
+    explanation: "Request bodies validate against OpenAPI schema before your code runs. Invalid data returns 400 automatically. No validation code to write."
+
+  - id: "16-2"
+    week: 16
+    day: 2
+    category: "API"
+    headline: "<Extract> the <email> from the <request: body: user: email>."
+    explanation: "Request body parsed per Content-Type header. JSON, form data handled automatically. Colons navigate nested fields. Schema validates structure."
+
+  # ===== WEEK 17: Path Parameters =====
+  - id: "17-1"
+    week: 17
+    day: 1
+    category: "API"
+    headline: "/users/{userId}/orders/{orderId}"
+    explanation: "Define path parameters in OpenAPI. They're available in your code automatically. Type coercion included. No parsing code needed."
+
+  - id: "17-2"
+    week: 17
+    day: 2
+    category: "API"
+    headline: "<Extract> the <userId> from the <pathParameters: userId>."
+    explanation: "OpenAPI path parameters map to pathParameters object. Access by name. Types validated per schema. Integer paths become integers."
+
+  # ===== WEEK 18: Repository Observers =====
+  - id: "18-1"
+    week: 18
+    day: 1
+    category: "Data"
+    headline: "(Audit Log: user-repository Observer)"
+    explanation: "Repository observers trigger on store, update, delete. Build audit logs, sync caches, send notifications. Change data capture built in."
+
+  - id: "18-2"
+    week: 18
+    day: 2
+    category: "Data"
+    headline: "<Extract> the <user> from the <change: entity>."
+    explanation: "Observer receives change object. change:entity is the affected record. change:operation is store/update/delete. React to any data mutation."
+
+  # ===== WEEK 19: Prepositions =====
+  - id: "19-1"
+    week: 19
+    day: 1
+    category: "Syntax"
+    headline: "from | to | with | for | into | via"
+    explanation: "Prepositions carry semantic meaning. from=source, to=destination, with=parameters, for=purpose, into=container, via=method."
+
+  - id: "19-2"
+    week: 19
+    day: 2
+    category: "Syntax"
+    headline: "<Store> the <user> into the <user-repository>."
+    explanation: "into emphasizes insertion into a container. to emphasizes sending to a destination. Both work with Store. Grammar guides intent."
+
+  - id: "19-3"
+    week: 19
+    day: 3
+    category: "Syntax"
+    headline: "<Send> the <email> to the <user: address> via <smtp>."
+    explanation: "via specifies the transport method. to specifies the destination. Prepositions make data flow explicit in the code."
+
+  # ===== WEEK 20: HTTP Client =====
+  - id: "20-1"
+    week: 20
+    day: 1
+    category: "HTTP"
+    headline: "<Request> the <data> from the <api: url>."
+    explanation: "Call external services without HTTP library setup. Headers, auth, timeouts in config object. Response parsing included. Integration simplified."
+
+  - id: "20-2"
+    week: 20
+    day: 2
+    category: "HTTP"
+    headline: "<Request> the <response> from <api> with { method: \"POST\", body: <data> }."
+    explanation: "Config object for method, headers, body, timeout. from for GET, to for POST. Response includes status, headers, body."
+
+  # ===== WEEK 21: Pattern Matching =====
+  - id: "21-1"
+    week: 21
+    day: 1
+    category: "Syntax"
+    headline: "match <status> { case \"active\" => ... }"
+    explanation: "Pattern matching replaces nested if-else chains. Business rules expressed clearly. Each case documents a scenario. Logic is self-documenting."
+
+  - id: "21-2"
+    week: 21
+    day: 2
+    category: "Syntax"
+    headline: "case \"pending\" => <Return> an <Accepted>."
+    explanation: "Match tests value against patterns. case for each pattern. otherwise for fallback. Value, type, and regex patterns supported."
+
+  # ===== WEEK 22: File Read/Write =====
+  - id: "22-1"
+    week: 22
+    day: 1
+    category: "Files"
+    headline: "<Read> the <content> from the <file: ./data.json>."
+    explanation: "Read, write, copy, move, delete files with simple actions. No streams to manage. No buffers to allocate. Cross-platform paths handled."
+
+  - id: "22-2"
+    week: 22
+    day: 2
+    category: "Files"
+    headline: "<Write> the <users> to the <file: ./data.json>."
+    explanation: "File extension determines format. .json writes JSON, .yaml writes YAML, .csv writes CSV. Format detection is automatic."
+
+  - id: "22-3"
+    week: 22
+    day: 3
+    category: "Files"
+    headline: ".json | .yaml | .csv | .xml | .toml"
+    explanation: "12 formats supported: json, jsonl, yaml, xml, toml, csv, tsv, md, html, txt, sql, log. Extension is format. Round-trip just works."
+
+  - id: "22-4"
+    week: 22
+    day: 4
+    category: "Files"
+    headline: "<Write> the <logs> to the <file: ./events.jsonl>."
+    explanation: ".jsonl writes one JSON object per line. .csv adds headers automatically. .sql generates INSERT statements. .md creates tables."
+
+  - id: "22-5"
+    week: 22
+    day: 5
+    category: "Files"
+    headline: "<Write> the <data> to <file> with { delimiter: \";\" }."
+    explanation: "CSV/TSV options: delimiter, header, quote, encoding. Override defaults with config object. Same options work for reading."
+
+  # ===== WEEK 23: File Watching =====
+  - id: "23-1"
+    week: 23
+    day: 1
+    category: "Files"
+    headline: "<Watch> the <directory: ./uploads>."
+    explanation: "Monitor directories for new, modified, deleted files. Build file processors, backup systems, sync tools. Platform-native performance."
+
+  - id: "23-2"
+    week: 23
+    day: 2
+    category: "Files"
+    headline: "(Process Upload: File Event Handler)"
+    explanation: "File Event Handler receives notifications. event:path is the changed file. event:type is created/modified/deleted. React to filesystem changes."
+
+  # ===== WEEK 24: Publish =====
+  - id: "24-1"
+    week: 24
+    day: 1
+    category: "Data"
+    headline: "<Publish> as <config> the <settings>."
+    explanation: "Publish makes variables globally accessible. Feature sets share config, computed values, state. No dependency injection. No service locators."
+
+  - id: "24-2"
+    week: 24
+    day: 2
+    category: "Data"
+    headline: "<Extract> the <timeout> from the <config: timeout>."
+    explanation: "Access published variables by alias. Original name stays local. Other feature sets use the published alias. Clean separation of concerns."
+
+  # ===== WEEK 25: Validate =====
+  - id: "25-1"
+    week: 25
+    day: 1
+    category: "Actions"
+    headline: "<Validate> the <email> with required, email."
+    explanation: "Chain validators with commas. Built-in rules for common cases. Validation logic centralized and reusable. Fails fast on first error."
+
+  - id: "25-2"
+    week: 25
+    day: 2
+    category: "Actions"
+    headline: "required | exists | nonempty | email | numeric"
+    explanation: "Built-in validators: required (not null), exists (in repository), nonempty (length > 0), email (valid format), numeric (is number)."
+
+  # ===== WEEK 26: Create =====
+  - id: "26-1"
+    week: 26
+    day: 1
+    category: "Actions"
+    headline: "<Create> the <user> with { name: \"Alice\", role: \"admin\" }."
+    explanation: "Create typed objects from literals. OpenAPI types become runtime objects. No separate DTO classes. Schema is the model."
+
+  - id: "26-2"
+    week: 26
+    day: 2
+    category: "Actions"
+    headline: "<Create> the <order> from the <template> with <overrides>."
+    explanation: "from provides base object. with provides overrides. Merged into new object. Original unchanged. Immutable data patterns."
+
+  # ===== WEEK 27: Iteration =====
+  - id: "27-1"
+    week: 27
+    day: 1
+    category: "Syntax"
+    headline: "for each <item> in <list> { ... }"
+    explanation: "Iterate without index management. Parallel option for independent items. Index available when needed. Clean, readable loops."
+
+  - id: "27-2"
+    week: 27
+    day: 2
+    category: "Syntax"
+    headline: "for each <user> at <index> in <users> { }"
+    explanation: "at binds the current index (0-based). parallel for each runs iterations concurrently. Both optional. Use what you need."
+
+  # ===== WEEK 28: Guards =====
+  - id: "28-1"
+    week: 28
+    day: 1
+    category: "Syntax"
+    headline: "<Return> a <Created> when <valid> is true."
+    explanation: "Add conditions without nesting. Statement runs only when guard is true. Cleaner than if-then for simple cases. Business rules stay visible."
+
+  - id: "28-2"
+    week: 28
+    day: 2
+    category: "Syntax"
+    headline: "<Emit> an <Alert: event> when <count> > 100."
+    explanation: "when clause guards any statement. Condition follows when. Supports comparison operators: is, >, <, >=, <=, contains."
+
+  # ===== WEEK 29: Split =====
+  - id: "29-1"
+    week: 29
+    day: 1
+    category: "Actions"
+    headline: "<Split> the <parts> from the <csv-line> by \",\"."
+    explanation: "Split strings into parts. Handle CSV, logs, structured text. String or regex delimiter. Text processing built in."
+
+  - id: "29-2"
+    week: 29
+    day: 2
+    category: "Actions"
+    headline: "<Split> the <words> from the <text> by /\\s+/."
+    explanation: "Regex delimiter after by. Flags: i (case-insensitive), g (global), m (multiline). Pattern in slashes."
+
+  # ===== WEEK 30: Filter/Map/Reduce =====
+  - id: "30-1"
+    week: 30
+    day: 1
+    category: "Data"
+    headline: "<Filter> the <active> from <users> where <active> is true."
+    explanation: "Transform collections without loops. Filter, map, reduce express intent clearly. Chain operations for complex transformations."
+
+  - id: "30-2"
+    week: 30
+    day: 2
+    category: "Data"
+    headline: "<Map> the <names> from the <users: name>."
+    explanation: "Map extracts a field from each item. Qualifier specifies which field. Result is list of that field's values."
+
+  - id: "30-3"
+    week: 30
+    day: 3
+    category: "Data"
+    headline: "<Reduce> the <total> from the <orders: amount> with sum."
+    explanation: "Reduce aggregates to single value. sum, avg, min, max, count built in. with specifies the aggregation function."
+
+  # ===== WEEK 31: Regex =====
+  - id: "31-1"
+    week: 31
+    day: 1
+    category: "Syntax"
+    headline: "/[a-z]+@[a-z]+\\.[a-z]+/i"
+    explanation: "Match complex text patterns. Validate formats, extract parts, transform strings. Regex is a first-class feature, not a library."
+
+  - id: "31-2"
+    week: 31
+    day: 2
+    category: "Syntax"
+    headline: "<Match> the <email> against /^[\\w]+@[\\w]+\\.[\\w]+$/."
+    explanation: "Match tests value against pattern. Returns boolean. Use in when guards. Flags after closing slash: i, g, m, s."
+
+  # ===== WEEK 32: List Access =====
+  - id: "32-1"
+    week: 32
+    day: 1
+    category: "Data"
+    headline: "<first> | <last> | <items: 0> | <items: 2-5>"
+    explanation: "Get first, last, or any element by index. Ranges and picks for slices. No off-by-one errors. Access patterns match intent."
+
+  - id: "32-2"
+    week: 32
+    day: 2
+    category: "Data"
+    headline: "<Extract> the <third> from the <items: 2>."
+    explanation: "Numeric qualifier is 0-based index. Ranges: 2-5 (inclusive). Picks: 0,3,7 (specific indices). Negative from end: -1 is last."
+
+  # ===== WEEK 33: Testing =====
+  - id: "33-1"
+    week: 33
+    day: 1
+    category: "Testing"
+    headline: "(add-numbers: Calculator Test)"
+    explanation: "Test suffix marks test feature sets. Tests in same .aro file as production code. Stripped from compiled binaries. Zero overhead."
+
+  - id: "33-2"
+    week: 33
+    day: 2
+    category: "Testing"
+    headline: "<Given> the <a> with 5."
+    explanation: "Given binds test data. Sets up preconditions. Works like Create but semantically for testing. BDD-style setup."
+
+  - id: "33-3"
+    week: 33
+    day: 3
+    category: "Testing"
+    headline: "<When> the <result> from the <add-numbers>."
+    explanation: "When executes a feature set. Passes current context as input. Captures result. Calls the feature set under test."
+
+  - id: "33-4"
+    week: 33
+    day: 4
+    category: "Testing"
+    headline: "<Then> the <result> with 8."
+    explanation: "Then asserts expected value. Throws AssertionError on mismatch. Assert is synonym. Failure message includes actual vs expected."
+
+  - id: "33-5"
+    week: 33
+    day: 5
+    category: "Testing"
+    headline: "aro test ./MyApp --verbose"
+    explanation: "Run all tests in directory. --verbose shows pass/fail for each. --filter to run subset. Exit code indicates success."
+
+  # ===== WEEK 34: State Transitions =====
+  - id: "34-1"
+    week: 34
+    day: 1
+    category: "State"
+    headline: "<Accept> the <transition: draft_to_placed> on <order: status>."
+    explanation: "Accept validates and applies state transition. States defined in OpenAPI enums. Invalid transitions throw descriptive errors."
+
+  - id: "34-2"
+    week: 34
+    day: 2
+    category: "State"
+    headline: "draft | placed | paid | shipped | delivered"
+    explanation: "States are OpenAPI enum values. from_to_target syntax: draft_to_placed. Runtime checks current state matches 'from'."
+
+  # ===== WEEK 35: State Observers =====
+  - id: "35-1"
+    week: 35
+    day: 1
+    category: "State"
+    headline: "(Track Shipment: status StateObserver)"
+    explanation: "React to state changes automatically. Log transitions, send notifications, update analytics. Observers run after Accept succeeds."
+
+  - id: "35-2"
+    week: 35
+    day: 2
+    category: "State"
+    headline: "(Notify: status StateObserver<paid_to_shipped>)"
+    explanation: "Filter specific transitions with angle brackets. Only triggers for that transition. Multiple observers per transition allowed."
+
+  # ===== WEEK 36: Type Annotations =====
+  - id: "36-1"
+    week: 36
+    day: 1
+    category: "Syntax"
+    headline: "<users> as List<User>"
+    explanation: "ARO infers types automatically. Add explicit types for documentation or to override inference. Optional, not required."
+
+  - id: "36-2"
+    week: 36
+    day: 2
+    category: "Syntax"
+    headline: "<Filter> the <active> as List from <users>."
+    explanation: "as keyword for type annotation. Clearer than colon syntax. Works on Filter, Map, Reduce results. Both syntaxes valid."
+
+  # ===== WEEK 37: Sockets =====
+  - id: "37-1"
+    week: 37
+    day: 1
+    category: "Sockets"
+    headline: "<Listen> on port 9000 as <socket-server>."
+    explanation: "Start a TCP socket server. Accept incoming connections. SwiftNIO powered. Combine with Keepalive for long-running servers."
+
+  - id: "37-2"
+    week: 37
+    day: 2
+    category: "Sockets"
+    headline: "(Echo: Socket Event Handler)"
+    explanation: "Socket Event Handler receives connection events. event:data is received bytes. event:connection identifies the client."
+
+  - id: "37-3"
+    week: 37
+    day: 3
+    category: "Sockets"
+    headline: "<Send> the <response> to the <client>."
+    explanation: "Send data to a specific connected client. client is the connection from the event. Bidirectional real-time communication."
+
+  - id: "37-4"
+    week: 37
+    day: 4
+    category: "Sockets"
+    headline: "<Broadcast> the <message> to the <socket-server>."
+    explanation: "Send to all connected clients at once. No loops, no tracking. Server manages connections automatically. Chat, dashboards, live updates."
+
+  # ===== WEEK 38: Socket Client =====
+  - id: "38-1"
+    week: 38
+    day: 1
+    category: "Sockets"
+    headline: "<Connect> to <host: 192.168.1.100> on port 8080."
+    explanation: "Connect to external TCP services. Databases, message brokers, legacy systems. Returns connection for Send/Receive."
+
+  - id: "38-2"
+    week: 38
+    day: 2
+    category: "Sockets"
+    headline: "<Close> the <connection>."
+    explanation: "Close when done. Graceful shutdown. Events for connection closed. Clean resource management."
+
+  # ===== WEEK 39: Execute =====
+  - id: "39-1"
+    week: 39
+    day: 1
+    category: "DevOps"
+    headline: "<Execute> the <result> for <command: \"git status\">."
+    explanation: "Sometimes you need the system. Execute runs commands, captures output. Build tools, deployment scripts, system integration."
+
+  - id: "39-2"
+    week: 39
+    day: 2
+    category: "DevOps"
+    headline: "<result: exitCode> | <result: stdout> | <result: stderr>"
+    explanation: "Result has exitCode (0=success), stdout (output), stderr (errors). Access with colon qualifier. Check exitCode for success."
+
+  # ===== WEEK 40: File Operations =====
+  - id: "40-1"
+    week: 40
+    day: 1
+    category: "Files"
+    headline: "<Copy> the <source> to the <destination>."
+    explanation: "Copy, move, delete without shell commands. Recursive directory operations. Cross-platform paths. File tasks in ARO style."
+
+  - id: "40-2"
+    week: 40
+    day: 2
+    category: "Files"
+    headline: "<Move> | <Delete> | <Make>"
+    explanation: "Move relocates files/dirs. Delete removes. Make creates directories. Paths auto-normalized per platform."
+
+  - id: "40-3"
+    week: 40
+    day: 3
+    category: "Files"
+    headline: "<Stat> the <info> for the <file: ./data.json>."
+    explanation: "Stat returns metadata: size, permissions, created, modified, accessed timestamps. Check existence before operations."
+
+  # ===== WEEK 41: Event Chains =====
+  - id: "41-1"
+    week: 41
+    day: 1
+    category: "Events"
+    headline: "OrderPlaced => SendEmail => LogActivity"
+    explanation: "Events trigger handlers that emit more events. Complex workflows emerge from simple parts. No workflow engine needed."
+
+  - id: "41-2"
+    week: 41
+    day: 2
+    category: "Events"
+    headline: "(Step Two: StepOneCompleted Handler)"
+    explanation: "Handler receives event, processes, emits new event. Next handler receives that. Chain continues automatically. Decoupled workflows."
+
+  # ===== WEEK 42: Multiple Handlers =====
+  - id: "42-1"
+    week: 42
+    day: 1
+    category: "Events"
+    headline: "UserCreated => Email + Analytics + CRM"
+    explanation: "One event triggers multiple handlers. Email, analytics, CRM all react to UserCreated. Add handlers without changing producer."
+
+  - id: "42-2"
+    week: 42
+    day: 2
+    category: "Events"
+    headline: "(A: UserCreated Handler) + (B: UserCreated Handler)"
+    explanation: "Multiple feature sets with same Handler suffix. All receive the event. Execution order non-deterministic. Design for independence."
+
+  # ===== WEEK 43: IDE =====
+  - id: "43-1"
+    week: 43
+    day: 1
+    category: "IDE"
+    headline: "aro lsp"
+    explanation: "Start the language server. VS Code, IntelliJ, any LSP editor. Real-time errors as you type. Go to definition. Find all references."
+
+  - id: "43-2"
+    week: 43
+    day: 2
+    category: "IDE"
+    headline: "Hover | Completion | Diagnostics"
+    explanation: "Hover shows types. Completion suggests actions, variables. Diagnostics publish on document change. One server, all editors."
+
+  # ===== WEEK 44: Happy Path =====
+  - id: "44-1"
+    week: 44
+    day: 1
+    category: "Philosophy"
+    headline: "No try-catch in ARO"
+    explanation: "Business logic describes success. Errors handled by runtime. No catch blocks obscuring intent. Code matches requirements directly."
+
+  - id: "44-2"
+    week: 44
+    day: 2
+    category: "Philosophy"
+    headline: "Statement text becomes error message"
+    explanation: "When 'Retrieve the user' fails, that's the error. Statements either succeed or fail. Failures become error responses automatically."
+
+  # ===== WEEK 45: Immutability =====
+  - id: "45-1"
+    week: 45
+    day: 1
+    category: "Philosophy"
+    headline: "Values never change after binding"
+    explanation: "Once bound, values are immutable within scope. No accidental overwrites. No state bugs. Reasoning about code is straightforward."
+
+  - id: "45-2"
+    week: 45
+    day: 2
+    category: "Syntax"
+    headline: "<Create> the <updated-user> with <user> + { role: \"admin\" }."
+    explanation: "Create new names for new values. Original unchanged. Same name in nested scope shadows outer. Functional data patterns."
+
+  # ===== WEEK 46: Swift Integration =====
+  - id: "46-1"
+    week: 46
+    day: 1
+    category: "DevOps"
+    headline: "struct MyAction: ActionImplementation"
+    explanation: "Custom actions in Swift. Access the entire Swift ecosystem. Use ARO for business logic, Swift for system integration."
+
+  - id: "46-2"
+    week: 46
+    day: 2
+    category: "DevOps"
+    headline: "ActionRegistry.shared.register(MyAction.self)"
+    explanation: "Register with ActionRegistry. Your action available as ARO verb. Full async/await support. Protocol-based extension point."
+
+  # ===== WEEK 47: LLVM =====
+  - id: "47-1"
+    week: 47
+    day: 1
+    category: "Compiler"
+    headline: "ARO => AST => LLVM IR => Native Binary"
+    explanation: "LLVM backend means proven optimization. Same technology as Rust, Swift, Clang. Production-grade code generation."
+
+  - id: "47-2"
+    week: 47
+    day: 2
+    category: "Compiler"
+    headline: "./MyApp (single executable)"
+    explanation: "Output is standalone executable. No interpreter, no dependencies. Container images shrink to megabytes. Deploy anywhere."
+
+  # ===== WEEK 48: SwiftNIO =====
+  - id: "48-1"
+    week: 48
+    day: 1
+    category: "HTTP"
+    headline: "http-server powered by SwiftNIO"
+    explanation: "SwiftNIO powers Apple's server ecosystem. High performance, low latency. Production-proven at scale. ARO inherits this reliability."
+
+  - id: "48-2"
+    week: 48
+    day: 2
+    category: "HTTP"
+    headline: "Async request handling, keep-alive"
+    explanation: "Start action launches SwiftNIO server. Async request handling. Keep-alive connections. Production-ready without configuration."
+
+  # ===== WEEK 49: Sendable =====
+  - id: "49-1"
+    week: 49
+    day: 1
+    category: "Compiler"
+    headline: "All core types are Sendable"
+    explanation: "Swift 6 concurrency safety built in. Async/await throughout. No data races. Modern concurrency model."
+
+  - id: "49-2"
+    week: 49
+    day: 2
+    category: "Compiler"
+    headline: "Feature sets execute concurrently"
+    explanation: "AST nodes, tokens, symbol tables are Sendable. Event handlers run in parallel. Thread-safe by design. Scale with cores."
+
+  # ===== WEEK 50: Qualifier Syntax =====
+  - id: "50-1"
+    week: 50
+    day: 1
+    category: "Syntax"
+    headline: "<first-len: length> and <second-len: length>"
+    explanation: "Compute length twice? Name them differently. Base becomes variable name. Qualifier specifies operation. Clear data flow."
+
+  - id: "50-2"
+    week: 50
+    day: 2
+    category: "Syntax"
+    headline: "<Compute> the <upper: uppercase> from the <text>."
+    explanation: "Operation as qualifier: length, count, uppercase, lowercase, hash. Result stored in base name. No variable shadowing."
+
+  # ===== WEEK 51: Comments =====
+  - id: "51-1"
+    week: 51
+    day: 1
+    category: "Syntax"
+    headline: "(* This is a comment *)"
+    explanation: "Comments use (* *) delimiters. Multi-line supported. Nest comments freely. Document intent, not implementation."
+
+  - id: "51-2"
+    week: 51
+    day: 2
+    category: "Syntax"
+    headline: "(* Calculate the user's total spending *)"
+    explanation: "Comments between statements. Explain business rules. Comments stripped from compiled output. Zero runtime overhead."
+
+  # ===== WEEK 52: Log =====
+  - id: "52-1"
+    week: 52
+    day: 1
+    category: "Actions"
+    headline: "<Log> the <message> for the <console> with \"Starting...\"."
+    explanation: "Log outputs to console or log files. for specifies destination. with provides the message. Structured logging built in."
+
+  - id: "52-2"
+    week: 52
+    day: 2
+    category: "Actions"
+    headline: "<Log> the <event> for the <file: ./app.log> with <data>."
+    explanation: "Log to files with automatic timestamps. JSON objects logged as JSON. Append mode by default. Rotation configurable."

--- a/cards/generate.js
+++ b/cards/generate.js
@@ -1,0 +1,374 @@
+import puppeteer from 'puppeteer';
+import yaml from 'js-yaml';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Design tokens from the ARO website
+const design = {
+  dark: {
+    background: '#0a0a0f',
+    text: '#e8e8ed',
+    textMuted: '#8888a0',
+    gradientStart: '#7c3aed',
+    gradientEnd: '#06b6d4',
+    glowColor: 'rgba(124, 58, 237, 0.3)',
+  },
+  light: {
+    background: '#f8f9fc',
+    text: '#1a1a2e',
+    textMuted: '#5c5c7a',
+    gradientStart: '#6d28d9',
+    gradientEnd: '#0891b2',
+    glowColor: 'rgba(109, 40, 217, 0.15)',
+  }
+};
+
+// Category colors for visual distinction
+const categoryColors = {
+  'Syntax': '#7c3aed',
+  'HTTP': '#06b6d4',
+  'Events': '#f472b6',
+  'Lifecycle': '#10b981',
+  'Data': '#f59e0b',
+  'Services': '#06b6d4',
+  'DevOps': '#10b981',
+  'Philosophy': '#a855f7',
+  'Actions': '#ec4899',
+  'Files': '#22c55e',
+  'Testing': '#eab308',
+  'Business': '#3b82f6',
+  'Contract': '#0ea5e9',
+  'API': '#14b8a6',
+  'State': '#8b5cf6',
+  'Sockets': '#f97316',
+  'IDE': '#84cc16',
+  'Compiler': '#ef4444',
+};
+
+function generateCombinedHTML(fact) {
+  const dark = design.dark;
+  const light = design.light;
+  const categoryColor = categoryColors[fact.category] || dark.gradientStart;
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      width: 1200px;
+      height: 1200px;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ===== FRONT SECTION (Top Half - Dark) ===== */
+    .front {
+      width: 1200px;
+      height: 600px;
+      background: ${dark.background};
+      color: ${dark.text};
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      padding: 40px 60px;
+    }
+
+    .front .glow-1 {
+      position: absolute;
+      width: 500px;
+      height: 500px;
+      border-radius: 50%;
+      background: radial-gradient(circle, ${dark.glowColor} 0%, transparent 70%);
+      top: -150px;
+      left: -100px;
+      pointer-events: none;
+    }
+
+    .front .glow-2 {
+      position: absolute;
+      width: 400px;
+      height: 400px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(6, 182, 212, 0.15) 0%, transparent 70%);
+      bottom: -100px;
+      right: -50px;
+      pointer-events: none;
+    }
+
+    .front .content {
+      position: relative;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .front .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      width: 100%;
+      margin-bottom: auto;
+    }
+
+    .front .headline-wrapper {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+    }
+
+    .front .logo {
+      font-size: 48px;
+      font-weight: 700;
+      background: linear-gradient(135deg, ${dark.gradientStart}, ${dark.gradientEnd});
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .front .category {
+      font-size: 20px;
+      font-weight: 600;
+      color: ${categoryColor};
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    .front .headline {
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 54px;
+      font-weight: 600;
+      line-height: 1.2;
+      text-align: center;
+      background: linear-gradient(135deg, ${dark.gradientStart}, ${dark.gradientEnd});
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    /* ===== BACK SECTION (Bottom Half - Light) ===== */
+    .back {
+      width: 1200px;
+      height: 600px;
+      background: ${light.background};
+      color: ${light.text};
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      padding: 40px 60px;
+    }
+
+    .back .glow-1 {
+      position: absolute;
+      width: 500px;
+      height: 500px;
+      border-radius: 50%;
+      background: radial-gradient(circle, ${light.glowColor} 0%, transparent 70%);
+      top: -150px;
+      left: -100px;
+      pointer-events: none;
+    }
+
+    .back .glow-2 {
+      position: absolute;
+      width: 400px;
+      height: 400px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(6, 182, 212, 0.1) 0%, transparent 70%);
+      bottom: -100px;
+      right: -50px;
+      pointer-events: none;
+    }
+
+    .back .content {
+      position: relative;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .back .explanation {
+      font-size: 36px;
+      font-weight: 400;
+      line-height: 1.4;
+      text-align: center;
+      color: ${light.text};
+    }
+
+    .back .footer {
+      margin-top: 25px;
+      font-size: 18px;
+      color: ${light.textMuted};
+    }
+
+    /* Divider line between sections */
+    .divider {
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg,
+        transparent 0%,
+        ${dark.gradientStart} 20%,
+        ${dark.gradientEnd} 80%,
+        transparent 100%
+      );
+    }
+  </style>
+</head>
+<body>
+  <!-- FRONT (Top Half - Dark) -->
+  <div class="front">
+    <div class="glow-1"></div>
+    <div class="glow-2"></div>
+
+    <div class="content">
+      <div class="header">
+        <div class="logo">ARO</div>
+        <div class="category">${fact.category}</div>
+      </div>
+
+      <div class="headline-wrapper">
+        <div class="headline">${escapeHtml(fact.headline)}</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- BACK (Bottom Half - Light) -->
+  <div class="back">
+    <div class="glow-1"></div>
+    <div class="glow-2"></div>
+
+    <div class="content">
+      <div class="explanation">${escapeHtml(fact.explanation)}</div>
+
+      <div class="footer">github.com/KrisSimon/ARO</div>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function toTitleCase(str) {
+  // Convert headline to PascalCase topic name
+  return str
+    .replace(/<[^>]+>/g, '') // Remove angle bracket tags
+    .replace(/[^a-zA-Z0-9\s]/g, '') // Remove special chars
+    .split(/\s+/)
+    .filter(word => word.length > 0)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join('');
+}
+
+async function generateCard(browser, fact, index) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 1200 });
+
+  // Use explicit week/day (required for all entries)
+  const week = String(fact.week).padStart(2, '0');
+  const day = fact.day;
+
+  const topic = toTitleCase(fact.headline);
+  const baseName = `${week}-${day}-${fact.category}-${topic}`;
+
+  // Generate combined card (front on top, back on bottom)
+  console.log(`  Generating: ${baseName}.png`);
+  const html = generateCombinedHTML(fact);
+  await page.setContent(html, { waitUntil: 'networkidle0' });
+  await page.screenshot({
+    path: path.join(__dirname, 'output', `${baseName}.png`),
+    type: 'png'
+  });
+
+  await page.close();
+}
+
+async function main() {
+  console.log('ARO Card Generator');
+  console.log('==================\n');
+  console.log('Layout: Combined (Front top, Back bottom)');
+  console.log('Dimensions: 1200x1200 (1:1 square)');
+  console.log('Naming: Week-Day (01-1, 01-2, 02-1, ...)\n');
+
+  // Load facts from YAML
+  const yamlPath = path.join(__dirname, 'facts.yaml');
+  const yamlContent = fs.readFileSync(yamlPath, 'utf8');
+  const data = yaml.load(yamlContent);
+
+  console.log(`Loaded ${data.facts.length} facts from facts.yaml\n`);
+
+  // Ensure output directory exists
+  const outputDir = path.join(__dirname, 'output');
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  // Clear existing output files
+  const existingFiles = fs.readdirSync(outputDir).filter(f => f.endsWith('.png'));
+  if (existingFiles.length > 0) {
+    console.log(`Clearing ${existingFiles.length} existing PNG files...\n`);
+    existingFiles.forEach(f => fs.unlinkSync(path.join(outputDir, f)));
+  }
+
+  // Launch browser
+  console.log('Launching browser...\n');
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+
+  try {
+    // Generate cards for each fact
+    for (let i = 0; i < data.facts.length; i++) {
+      const fact = data.facts[i];
+      console.log(`[Week ${fact.week} Day ${fact.day}] ${fact.id}`);
+      await generateCard(browser, fact, i);
+    }
+
+    console.log('\n==================');
+    console.log(`Generated ${data.facts.length} combined cards in ./output/`);
+    console.log('Each card is 1200x1200 pixels (1:1)');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch(console.error);

--- a/cards/package-lock.json
+++ b/cards/package-lock.json
@@ -1,0 +1,1202 @@
+{
+  "name": "aro-cards",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aro-cards",
+      "version": "1.0.0",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "puppeteer": "^23.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz",
+      "integrity": "sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==",
+      "deprecated": "< 24.15.0 is no longer supported",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.11.1",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cards/package.json
+++ b/cards/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aro-cards",
+  "version": "1.0.0",
+  "description": "Generate promotional cards for ARO language features",
+  "type": "module",
+  "scripts": {
+    "generate": "node generate.js"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "puppeteer": "^23.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Puppeteer-based card generator for ARO promotional content
- 122 cards covering 52 weeks with up to 5 cards per week (1-5)
- Real ARO syntax in every headline with explanations on the back
- 16 categories: Philosophy, Syntax, Contract, API, HTTP, Events, Data, Files, Actions, Testing, State, Sockets, Lifecycle, Compiler, DevOps, IDE
- 1200x1200 PNG output (dark theme front on top, light theme back on bottom)

## Files
- `cards/facts.yaml` - Card content (week, day, category, headline, explanation)
- `cards/generate.js` - Puppeteer generator script
- `cards/package.json` - Dependencies (puppeteer, js-yaml)
- `cards/.gitignore` - Ignores output/ and node_modules/

## Usage
```bash
cd cards
npm install
node generate.js
```

## Test plan
- [x] Run `node generate.js` and verify 122 PNG files in `output/`
- [x] Verify naming convention: `WW-D-Category-Topic.png`
- [x] Verify all cards have week/day properties (1-5 for days)