### PR TITLE
docs(book): reindex chapters to sequential numbering (1-35)

### DIFF
--- a/Book/TheLanguageGuide/Chapter06-DataFlow.md
+++ b/Book/TheLanguageGuide/Chapter06-DataFlow.md
@@ -132,4 +132,4 @@ Document complex data flows when the structure is not obvious from the code. A c
 
 ---
 
-*Next: Chapter 7 — Computations*
+*Next: Chapter 8 — Computations*

--- a/Book/TheLanguageGuide/Chapter07-ExportActions.md
+++ b/Book/TheLanguageGuide/Chapter07-ExportActions.md
@@ -1,10 +1,10 @@
-# Chapter 6A: Export Actions
+# Chapter 7: Export Actions
 
 *"Know where your data goes."*
 
 ---
 
-## 6A.1 Three Paths Out
+## 7.1 Three Paths Out
 
 When data leaves your feature set, it takes one of three paths. Each path serves a distinct purpose in the ARO architecture. Understanding which path to choose is essential for building well-structured applications.
 
@@ -48,7 +48,7 @@ Each path has different characteristics that make it suitable for different scen
 
 ---
 
-## 6A.2 Store: Persistent Data
+## 7.2 Store: Persistent Data
 
 The Store action saves data to a named repository. Repositories are identified by names ending with `-repository`. This naming convention is not merely a style guide—the runtime uses this suffix to recognize storage targets.
 
@@ -135,7 +135,7 @@ The observer receives an event with details about the change:
 
 ---
 
-## 6A.3 Emit: Event-Driven Communication
+## 7.3 Emit: Event-Driven Communication
 
 The Emit action fires a domain event that triggers handlers in other feature sets. Unlike Store, the event payload is transient—it exists only during handler execution. Once all handlers complete, the event is gone.
 
@@ -233,7 +233,7 @@ This pattern enables complex workflows while keeping each handler focused on a s
 
 ---
 
-## 6A.4 Publish: Shared Values
+## 7.4 Publish: Shared Values
 
 The Publish action makes a value globally accessible without triggering any logic. Published values are available to other feature sets within the same business activity but do not cause handlers to execute.
 
@@ -282,7 +282,7 @@ Published values are scoped to the business activity. Feature sets in different 
 
 ---
 
-## 6A.5 Decision Guide
+## 7.5 Decision Guide
 
 Choosing between Store, Emit, and Publish becomes straightforward when you ask the right question.
 
@@ -339,7 +339,7 @@ Choosing between Store, Emit, and Publish becomes straightforward when you ask t
 
 ---
 
-## 6A.6 Common Mistakes
+## 7.6 Common Mistakes
 
 ### Using Emit for Persistence
 
@@ -466,7 +466,7 @@ Reserve Publish for truly shared values like configuration, not for communicatio
 
 ---
 
-## 6A.7 Complete Example: User Registration
+## 7.7 Complete Example: User Registration
 
 Here is a realistic example that uses all three export actions appropriately. The scenario is user registration with email verification, welcome notifications, and analytics tracking.
 
@@ -588,4 +588,4 @@ Each action serves its intended purpose, creating a well-structured, maintainabl
 
 ---
 
-*Next: Chapter 7 — Computations*
+*Next: Chapter 8 — Computations*

--- a/Book/TheLanguageGuide/Chapter08-Computations.md
+++ b/Book/TheLanguageGuide/Chapter08-Computations.md
@@ -1,10 +1,10 @@
-# Chapter 7: Computations
+# Chapter 8: Computations
 
 *"Transform what you have into what you need."*
 
 ---
 
-## 7.1 The OWN Role
+## 8.1 The OWN Role
 
 Among the four semantic roles in ARO—REQUEST, OWN, RESPONSE, and EXPORT—the OWN role occupies a special place. While REQUEST brings data in and RESPONSE sends it out, OWN is where the actual work happens. OWN actions transform data that already exists within the feature set, producing new values without external side effects.
 
@@ -16,7 +16,7 @@ This pattern—read, transform, bind—is the heartbeat of data processing in AR
 
 ---
 
-## 7.2 Built-in Computations
+## 8.2 Built-in Computations
 
 ARO provides several built-in computations that cover common transformation needs:
 
@@ -72,7 +72,7 @@ Here, the expression `<price> * <quantity>` is the actual computation. The resul
 
 ---
 
-## 7.3 Naming Your Results
+## 8.3 Naming Your Results
 
 A subtle problem arises when you need multiple results of the same operation. Consider computing the lengths of two different messages:
 
@@ -112,7 +112,7 @@ For backward compatibility, the original syntax still works. Writing `<Compute> 
 
 ---
 
-## 7.4 Set Operations
+## 8.4 Set Operations
 
 When working with collections, you often need to find commonalities or differences between datasets. ARO provides three polymorphic set operations that work across Lists, Strings, and Objects.
 
@@ -231,7 +231,7 @@ For objects, set operations perform **deep recursive comparison**. The intersect
 
 ---
 
-## 7.5 Extending Computations
+## 8.5 Extending Computations
 
 The built-in operations cover common cases, but real applications often need domain-specific computations. ARO's plugin system allows you to add custom operations that integrate seamlessly with the Compute action.
 
@@ -265,7 +265,7 @@ See Chapter 17 for the full plugin development guide.
 
 ---
 
-## 7.6 Computation Patterns
+## 8.6 Computation Patterns
 
 Several patterns emerge in how computations are used within feature sets.
 
@@ -305,4 +305,4 @@ Each pattern follows the read-transform-bind rhythm. Data flows forward, transfo
 
 ---
 
-*Next: Chapter 8 — Understanding Qualifiers*
+*Next: Chapter 9 — Understanding Qualifiers*

--- a/Book/TheLanguageGuide/Chapter09-QualifierSyntax.md
+++ b/Book/TheLanguageGuide/Chapter09-QualifierSyntax.md
@@ -1,10 +1,10 @@
-# Chapter 8: Understanding Qualifiers
+# Chapter 9: Understanding Qualifiers
 
 *"The colon is context-aware: it navigates data or selects operations."*
 
 ---
 
-## 8.1 The Two Roles of Qualifiers
+## 9.1 The Two Roles of Qualifiers
 
 Throughout ARO, you encounter the colon syntax `<name: qualifier>`. This compact notation carries significant meaning, but that meaning depends on context. Understanding when the colon navigates data versus when it selects operations is essential for writing clear ARO code.
 
@@ -19,7 +19,7 @@ This distinction matters because the same syntax produces fundamentally differen
 
 ---
 
-## 8.2 Operation Qualifiers
+## 9.2 Operation Qualifiers
 
 When using actions like Compute, Validate, Transform, or Sort, the qualifier specifies which operation to apply. The base identifier becomes the variable name for the result.
 
@@ -77,7 +77,7 @@ Now `greeting-length` holds 12 and `farewell-length` holds 8. Both values exist 
 
 ---
 
-## 8.3 Field Navigation Qualifiers
+## 9.3 Field Navigation Qualifiers
 
 When accessing data from objects, events, or requests, the qualifier navigates to nested properties. The qualifier acts as a path into the data structure.
 
@@ -125,7 +125,7 @@ For nested structures, use dot-separated paths:
 
 ---
 
-## 8.4 Type Annotations with `as`
+## 9.4 Type Annotations with `as`
 
 For data pipeline operations (Filter, Reduce, Map), you can optionally specify result types using the `as` keyword:
 
@@ -150,7 +150,7 @@ See ARO-0038 for the full specification.
 
 ---
 
-## 8.5 The Ambiguity Case
+## 9.5 The Ambiguity Case
 
 A natural question arises: what happens when data contains a field named like an operation?
 
@@ -185,7 +185,7 @@ This returns 42—the value of the `length` field.
 
 ---
 
-## 8.6 Best Practices
+## 9.6 Best Practices
 
 **Use descriptive base names with operation qualifiers:**
 
@@ -232,4 +232,4 @@ In summary, qualifiers serve two purposes: navigating data structures and select
 
 ---
 
-*Next: Chapter 9 — The Happy Path*
+*Next: Chapter 10 — The Happy Path*

--- a/Book/TheLanguageGuide/Chapter10-HappyPath.md
+++ b/Book/TheLanguageGuide/Chapter10-HappyPath.md
@@ -1,4 +1,4 @@
-# Chapter 9: The Happy Path
+# Chapter 10: The Happy Path
 
 *"Optimism is a strategy, not naivety."*
 
@@ -164,4 +164,4 @@ Design your domain model so that validation can be expressed through structure r
 
 ---
 
-*Next: Chapter 10 — The Event Bus*
+*Next: Chapter 11 — The Event Bus*

--- a/Book/TheLanguageGuide/Chapter11-EventBus.md
+++ b/Book/TheLanguageGuide/Chapter11-EventBus.md
@@ -1,4 +1,4 @@
-# Chapter 10: The Event Bus
+# Chapter 11: The Event Bus
 
 *"In an event-driven system, everything is a reaction."*
 
@@ -266,4 +266,4 @@ The separation between Accept and observers creates a clean architecture. Accept
 
 ---
 
-*Next: Chapter 11 — Application Lifecycle*
+*Next: Chapter 12 — Application Lifecycle*

--- a/Book/TheLanguageGuide/Chapter12-Lifecycle.md
+++ b/Book/TheLanguageGuide/Chapter12-Lifecycle.md
@@ -1,4 +1,4 @@
-# Chapter 11: Application Lifecycle
+# Chapter 12: Application Lifecycle
 
 *"Every program has a beginning, a middle, and an end."*
 
@@ -116,4 +116,4 @@ Keep shutdown handlers fast. Long shutdown times frustrate operators and can cau
 
 ---
 
-*Next: Chapter 12 — Custom Events*
+*Next: Chapter 13 — Custom Events*

--- a/Book/TheLanguageGuide/Chapter13-CustomEvents.md
+++ b/Book/TheLanguageGuide/Chapter13-CustomEvents.md
@@ -1,4 +1,4 @@
-# Chapter 12: Custom Events
+# Chapter 13: Custom Events
 
 *"Design your domain events like you design your domain model."*
 
@@ -210,4 +210,4 @@ The goal is to ensure that every event chain has a clear end point where no furt
 
 ---
 
-*Next: Chapter 13 — OpenAPI Integration*
+*Next: Chapter 14 — OpenAPI Integration*

--- a/Book/TheLanguageGuide/Chapter14-OpenAPI.md
+++ b/Book/TheLanguageGuide/Chapter14-OpenAPI.md
@@ -1,4 +1,4 @@
-# Chapter 13: OpenAPI Integration
+# Chapter 14: OpenAPI Integration
 
 *"Your contract is your router."*
 
@@ -134,4 +134,4 @@ Keep your specification and implementation synchronized. When you change the API
 
 ---
 
-*Next: Chapter 14 — HTTP Feature Sets*
+*Next: Chapter 15 — HTTP Feature Sets*

--- a/Book/TheLanguageGuide/Chapter15-HTTPFeatureSets.md
+++ b/Book/TheLanguageGuide/Chapter15-HTTPFeatureSets.md
@@ -1,4 +1,4 @@
-# Chapter 14: HTTP Feature Sets
+# Chapter 15: HTTP Feature Sets
 
 *"Every endpoint tells a story."*
 
@@ -198,4 +198,4 @@ Return appropriate status codes. Use Created for successful POST requests that c
 
 ---
 
-*Next: Chapter 15 — Request/Response Patterns*
+*Next: Chapter 16 — Request/Response Patterns*

--- a/Book/TheLanguageGuide/Chapter16-RequestResponse.md
+++ b/Book/TheLanguageGuide/Chapter16-RequestResponse.md
@@ -1,4 +1,4 @@
-# Chapter 15: Request/Response Patterns
+# Chapter 16: Request/Response Patterns
 
 *"Input, transform, output. The rhythm of every API."*
 
@@ -126,4 +126,4 @@ Handle edge cases explicitly. What happens when a list endpoint finds no matchin
 
 ---
 
-*Next: Chapter 16 — Built-in Services*
+*Next: Chapter 17 — Built-in Services*

--- a/Book/TheLanguageGuide/Chapter17-BuiltinServices.md
+++ b/Book/TheLanguageGuide/Chapter17-BuiltinServices.md
@@ -1,10 +1,10 @@
-# Chapter 16: Built-in Services
+# Chapter 17: Built-in Services
 
 *"Batteries included."*
 
 ---
 
-## 16.1 Available Services
+## 17.1 Available Services
 
 ARO provides five built-in services that handle common infrastructure concerns: an HTTP server for serving web requests, an HTTP client for making outbound requests, a file system service for reading and writing files, and socket services for TCP communication.
 
@@ -16,7 +16,7 @@ The services are designed to be sufficient for most application needs while rema
 
 ---
 
-## 16.2 HTTP Server
+## 17.2 HTTP Server
 
 The HTTP server handles incoming HTTP requests based on your OpenAPI specification. It provides a production-capable server built on SwiftNIO that efficiently handles concurrent connections.
 
@@ -30,7 +30,7 @@ Stopping the server during shutdown allows it to complete in-flight requests gra
 
 ---
 
-## 16.3 HTTP Client
+## 17.3 HTTP Client
 
 The HTTP client makes outbound HTTP requests to external services. It provides a high-performance client built on AsyncHTTPClient that handles connection pooling, timeouts, and retries.
 
@@ -44,7 +44,7 @@ Error handling follows the same happy path philosophy as other ARO operations. I
 
 ---
 
-## 16.4 File System Service
+## 17.4 File System Service
 
 The file system service provides comprehensive operations for reading, writing, and managing files and directories. It handles the mechanics of file I/O while you focus on what data to read or write.
 
@@ -169,7 +169,7 @@ File operations work consistently across macOS, Linux, and Windows. Path separat
 
 ---
 
-## 16.5 Socket Services
+## 17.5 Socket Services
 
 The socket server and client provide low-level TCP communication for applications that need more control than HTTP offers or that need to communicate using custom protocols.
 
@@ -183,7 +183,7 @@ For most web applications, HTTP is the appropriate choice. Use sockets when you 
 
 ---
 
-## 16.6 Service Lifecycle
+## 17.6 Service Lifecycle
 
 Services have a lifecycle that mirrors the application lifecycle. They start during Application-Start, run during the application's lifetime, and stop during Application-End.
 
@@ -197,7 +197,7 @@ The error shutdown handler (Application-End: Error) should also stop services, a
 
 ---
 
-## 16.7 Service Configuration
+## 17.7 Service Configuration
 
 Services accept configuration options that control their behavior. These options are passed when starting or using the service.
 
@@ -211,7 +211,7 @@ Configuration can be hardcoded in your ARO statements or loaded from external fi
 
 ---
 
-## 16.8 Practical Example: Services in Action
+## 17.8 Practical Example: Services in Action
 
 Here is a complete example demonstrating multiple built-in services working together. This application watches a directory for configuration changes and uses the HTTP client to report them to an external monitoring service.
 
@@ -275,7 +275,7 @@ This example shows:
 
 ---
 
-## 16.9 Best Practices
+## 17.9 Best Practices
 
 Start all services during Application-Start. Centralizing service startup in one place makes it clear what your application depends on and ensures consistent initialization order.
 
@@ -289,4 +289,4 @@ Configure services appropriately for your environment. Development might use per
 
 ---
 
-*Next: Chapter 17 — Custom Actions*
+*Next: Chapter 18 — Custom Actions*

--- a/Book/TheLanguageGuide/Chapter18-FormatAwareIO.md
+++ b/Book/TheLanguageGuide/Chapter18-FormatAwareIO.md
@@ -1,10 +1,10 @@
-# Chapter 16B: Format-Aware File I/O
+# Chapter 18: Format-Aware File I/O
 
 *"Structured data in, structured data out."*
 
 ---
 
-## 16B.1 The Format Detection Pattern
+## 18.1 The Format Detection Pattern
 
 When you write data to a file, ARO examines the file extension and automatically serializes your data to the appropriate format. When you read a file, ARO parses the content back into structured data. This eliminates the boilerplate of manual serialization and deserialization.
 
@@ -59,7 +59,7 @@ This pattern follows ARO's philosophy of reducing ceremony. The file path alread
 
 ---
 
-## 16B.2 Supported Formats
+## 18.2 Supported Formats
 
 ARO supports thirteen file formats out of the box. Each format has specific characteristics that make it suitable for different use cases.
 
@@ -82,7 +82,7 @@ ARO supports thirteen file formats out of the box. Each format has specific char
 
 ---
 
-## 16B.3 Writing Structured Data
+## 18.3 Writing Structured Data
 
 The Write action serializes your data according to the file extension. Each format has its own serialization rules.
 
@@ -315,7 +315,7 @@ debug=true
 
 ---
 
-## 16B.4 Reading Structured Data
+## 18.4 Reading Structured Data
 
 Reading files reverses the process. ARO examines the file extension and parses the content into structured data that you can work with.
 
@@ -402,7 +402,7 @@ This is useful when you need to inspect the raw content or pass it to an externa
 
 ---
 
-## 16B.5 CSV and TSV Options
+## 18.5 CSV and TSV Options
 
 CSV and TSV formats support additional configuration options. These options control how data is formatted when writing and how content is parsed when reading.
 
@@ -436,7 +436,7 @@ When reading, if your CSV has no header row, specify this so the parser knows to
 
 ---
 
-## 16B.6 Round-Trip Patterns
+## 18.6 Round-Trip Patterns
 
 A common pattern is reading data from one format and writing to another. ARO makes this seamless because the data structure is format-independent.
 
@@ -486,7 +486,7 @@ When you need to provide data in multiple formats for different consumers:
 
 ---
 
-## 16B.7 Best Practices
+## 18.7 Best Practices
 
 **Choose the right format for your use case.** JSON and YAML are best for configuration and API data. CSV is best for spreadsheet workflows. JSON Lines is best for logging and streaming. SQL is best for database backup.
 
@@ -500,4 +500,4 @@ When you need to provide data in multiple formats for different consumers:
 
 ---
 
-*Next: Chapter 17 — Custom Actions*
+*Next: Chapter 19 — Custom Actions*

--- a/Book/TheLanguageGuide/Chapter19-CustomActions.md
+++ b/Book/TheLanguageGuide/Chapter19-CustomActions.md
@@ -1,10 +1,10 @@
-# Chapter 17: Custom Actions
+# Chapter 19: Custom Actions
 
 *"When 50 actions aren't enough, write your own."*
 
 ---
 
-## 17.1 When to Create Custom Actions
+## 19.1 When to Create Custom Actions
 
 ARO's built-in actions cover common operations, but real applications often need capabilities beyond the standard set. Custom actions extend the language with domain-specific operations while maintaining ARO's declarative style.
 
@@ -18,7 +18,7 @@ Create custom actions when you want domain-specific operations that make your AR
 
 ---
 
-## 17.2 The Escape Hatch Pattern
+## 19.2 The Escape Hatch Pattern
 
 No constrained language survives contact with reality without an extension mechanism. This is the pattern that made other constrained languages successful: Terraform has providers, Ansible has modules, Make has recipes—and ARO has actions and services.
 
@@ -33,15 +33,15 @@ ARO provides two extension mechanisms:
 
 Custom actions, covered in this chapter, let you add new verbs to the language. When you implement a custom action, you can write statements like `<Geocode> the <coordinates> from the <address>` that feel native to ARO.
 
-Custom services, covered in Chapter 17B, let you integrate external systems through the `Call` action. Services provide multiple methods under a single service name: `<Call> from <postgres: query>`, `<Call> from <postgres: insert>`.
+Custom services, covered in Chapter 20, let you integrate external systems through the `Call` action. Services provide multiple methods under a single service name: `<Call> from <postgres: query>`, `<Call> from <postgres: insert>`.
 
-Plugins, covered in Chapter 18, let you package and share both actions and services with the community.
+Plugins, covered in Chapter 21, let you package and share both actions and services with the community.
 
 The rest of this chapter focuses on implementing custom actions—the fundamental building block of ARO's extensibility.
 
 ---
 
-## 17.3 The Action Protocol
+## 19.3 The Action Protocol
 
 Every custom action implements the ActionImplementation protocol. This protocol defines the structure that the runtime expects: a role indicating data flow direction, a set of verbs that trigger the action, valid prepositions that can appear with the action, and an execute method that performs the work.
 
@@ -55,7 +55,7 @@ The execute method does the actual work. It receives descriptors for the result 
 
 ---
 
-## 17.4 Accessing the Context
+## 19.4 Accessing the Context
 
 The execution context is your interface to the ARO runtime. Through it, you access values bound by previous statements, bind new values for subsequent statements, and interact with the event system.
 
@@ -69,7 +69,7 @@ The event bus is accessible through the context for emitting events. Your action
 
 ---
 
-## 17.5 Implementing an Action
+## 19.5 Implementing an Action
 
 Implementing a custom action follows a consistent pattern. You define a struct that conforms to ActionImplementation, specify the required static properties, and implement the execute method.
 
@@ -83,7 +83,7 @@ In the execute method, retrieve inputs from the context, perform your operation,
 
 ---
 
-## 17.6 Error Handling
+## 19.6 Error Handling
 
 Custom actions report errors by throwing Swift exceptions. The runtime catches these exceptions and converts them to ARO error messages that follow the happy path philosophy.
 
@@ -95,7 +95,7 @@ The runtime integrates your errors with its error handling system. HTTP handlers
 
 ---
 
-## 17.7 Async Operations
+## 19.7 Async Operations
 
 Custom actions can be asynchronous, which is essential for I/O operations. The execute method is declared async, so you can await async operations within it.
 
@@ -107,7 +107,7 @@ Timeouts and cancellation should be considered for long-running operations. If y
 
 ---
 
-## 17.8 Thread Safety
+## 19.8 Thread Safety
 
 Actions must be thread-safe because the runtime may execute them concurrently. Swift's Sendable protocol, which ActionImplementation requires, helps enforce this.
 
@@ -119,7 +119,7 @@ Avoid mutable shared state. If your action needs configuration, receive it durin
 
 ---
 
-## 17.9 Registration
+## 19.9 Registration
 
 Custom actions must be registered with the action registry before they can be used. Registration tells the runtime which action implementation handles which verbs.
 
@@ -131,7 +131,7 @@ Once registered, your action's verbs become available in ARO code. Statements us
 
 ---
 
-## 17.10 Best Practices
+## 19.10 Best Practices
 
 Single responsibility keeps actions focused and testable. Each action should do one thing well. If an action is doing multiple distinct operations, consider splitting it into multiple actions.
 
@@ -145,4 +145,4 @@ Test actions independently. Because actions have a well-defined interface, they 
 
 ---
 
-*Next: Chapter 17B — Custom Services*
+*Next: Chapter 20 — Custom Services*

--- a/Book/TheLanguageGuide/Chapter20-CustomServices.md
+++ b/Book/TheLanguageGuide/Chapter20-CustomServices.md
@@ -1,10 +1,10 @@
-# Chapter 17B: Custom Services
+# Chapter 20: Custom Services
 
 *"When you need to talk to the outside world."*
 
 ---
 
-## 17B.1 Actions vs Services: The Key Distinction
+## 20.1 Actions vs Services: The Key Distinction
 
 Before diving into custom services, it is essential to understand how they differ from custom actions. This distinction shapes how you design extensions to ARO.
 
@@ -42,7 +42,7 @@ When you add a service, you are saying "this external system provides capabiliti
 
 ---
 
-## 17B.2 The Service Protocol
+## 20.2 The Service Protocol
 
 Services implement the `AROService` protocol. This protocol defines the contract between your service and the ARO runtime.
 
@@ -69,7 +69,7 @@ The protocol is simpler than ActionImplementation because services have a unifor
 
 ---
 
-## 17B.3 Implementing a Service
+## 20.3 Implementing a Service
 
 Let us build a PostgreSQL service to illustrate the implementation pattern.
 
@@ -169,7 +169,7 @@ The call method dispatches to different operations based on the method parameter
 
 ---
 
-## 17B.4 Using Your Service in ARO
+## 20.4 Using Your Service in ARO
 
 Once registered, your service is available through the Call action:
 
@@ -209,7 +209,7 @@ Once registered, your service is available through the Call action:
 
 ---
 
-## 17B.5 Service Registration
+## 20.5 Service Registration
 
 Services must be registered before use. Registration happens during application initialization:
 
@@ -229,7 +229,7 @@ For plugin-based services (covered in Chapter 18), registration happens automati
 
 ---
 
-## 17B.6 Error Handling in Services
+## 20.6 Error Handling in Services
 
 Services report errors by throwing Swift exceptions. The runtime converts these to ARO error messages:
 
@@ -263,7 +263,7 @@ Cannot call postgres:query - Connection failed: Connection refused to localhost:
 
 ---
 
-## 17B.7 Complete Example: Redis Service
+## 20.7 Complete Example: Redis Service
 
 Here is a complete service implementation for Redis:
 
@@ -371,7 +371,7 @@ public struct RedisService: AROService {
 
 ---
 
-## 17B.8 Best Practices
+## 20.8 Best Practices
 
 **Name services clearly.** The service name appears in ARO code, so it should be short and recognizable. Use "postgres" not "postgresqlDatabaseService".
 
@@ -387,7 +387,7 @@ public struct RedisService: AROService {
 
 ---
 
-## 17B.9 Services vs Built-in Actions
+## 20.9 Services vs Built-in Actions
 
 Some capabilities in ARO are implemented as built-in actions rather than services. HTTP requests use the `Request` action, not a service:
 
@@ -411,4 +411,4 @@ The distinction: built-in actions are part of the ARO language and have dedicate
 
 ---
 
-*Next: Chapter 18 — Plugins*
+*Next: Chapter 21 — Plugins*

--- a/Book/TheLanguageGuide/Chapter21-Plugins.md
+++ b/Book/TheLanguageGuide/Chapter21-Plugins.md
@@ -1,10 +1,10 @@
-# Chapter 18: Plugins
+# Chapter 21: Plugins
 
 *"Package and share your extensions."*
 
 ---
 
-## 18.1 What Are Plugins?
+## 21.1 What Are Plugins?
 
 Plugins are Swift packages that provide custom actions and services for ARO applications. They allow you to package extensions together, share them across projects, and distribute them to other developers through Swift Package Manager.
 
@@ -21,7 +21,7 @@ The distinction matters for plugin design. Actions extend the language vocabular
 
 ---
 
-## 18.2 Plugin Structure
+## 21.2 Plugin Structure
 
 A plugin follows standard Swift package conventions with ARO-specific requirements. The package contains source files, a registration function, and optionally tests and documentation.
 
@@ -39,7 +39,7 @@ The package manifest declares the plugin as a dynamic library product. This enab
 
 ---
 
-## 18.3 Creating an Action Plugin
+## 21.3 Creating an Action Plugin
 
 Action plugins add new verbs to ARO. Here is a complete example of a Geocoding action plugin.
 
@@ -139,7 +139,7 @@ public func registerPlugin() {
 
 ---
 
-## 18.4 Creating a Service Plugin
+## 21.4 Creating a Service Plugin
 
 Service plugins provide external integrations called via the `Call` action. Here is a complete example of a Zip service plugin.
 
@@ -255,7 +255,7 @@ enum PluginError: Error {
 
 ---
 
-## 18.5 Choosing Between Action and Service Plugins
+## 21.5 Choosing Between Action and Service Plugins
 
 When designing a plugin, consider which approach fits better:
 
@@ -300,7 +300,7 @@ When designing a plugin, consider which approach fits better:
 
 ---
 
-## 18.6 Plugin Loading
+## 21.6 Plugin Loading
 
 Plugins load in two ways: compile-time linking and runtime discovery.
 
@@ -312,7 +312,7 @@ For runtime loading, place compiled `.dylib` (macOS), `.so` (Linux), or `.dll` (
 
 ---
 
-## 18.7 Plugin Design Guidelines
+## 21.7 Plugin Design Guidelines
 
 **Cohesion**: Group related functionality. A database plugin provides all database operations. A compression plugin provides all compression methods.
 
@@ -324,7 +324,7 @@ For runtime loading, place compiled `.dylib` (macOS), `.so` (Linux), or `.dll` (
 
 ---
 
-## 18.8 Documentation
+## 21.8 Documentation
 
 Document your plugin thoroughly:
 
@@ -337,7 +337,7 @@ A README should provide quick start instructions. Users should be productive wit
 
 ---
 
-## 18.9 Publishing
+## 21.9 Publishing
 
 Publish plugins through Git repositories. Swift Package Manager resolves dependencies from URLs.
 
@@ -357,7 +357,7 @@ dependencies: [
 
 ---
 
-## 18.10 Best Practices
+## 21.10 Best Practices
 
 **Test thoroughly.** Plugins may be used in unexpected ways. Test edge cases and error conditions.
 
@@ -369,4 +369,4 @@ dependencies: [
 
 ---
 
-*Next: Chapter 19 — Native Compilation*
+*Next: Chapter 22 — Native Compilation*

--- a/Book/TheLanguageGuide/Chapter22-NativeCompilation.md
+++ b/Book/TheLanguageGuide/Chapter22-NativeCompilation.md
@@ -1,10 +1,10 @@
-# Chapter 19: Native Compilation
+# Chapter 22: Native Compilation
 
 *"From script to standalone binary."*
 
 ---
 
-## 19.1 What Is Native Compilation?
+## 22.1 What Is Native Compilation?
 
 ARO can compile applications to standalone native binaries that run without the ARO runtime installed. This transforms your application from an interpreted script into a self-contained executable that can be deployed anywhere the target platform runs.
 
@@ -16,7 +16,7 @@ Native binaries also provide some intellectual property protection. While not im
 
 ---
 
-## 19.2 The Build Command
+## 22.2 The Build Command
 
 The aro build command compiles an ARO application to a native binary. You provide the path to your application directory, and the compiler produces an executable.
 
@@ -30,7 +30,7 @@ Verbose output shows what the compiler is doing at each step: discovering source
 
 ---
 
-## 19.3 The Compilation Pipeline
+## 22.3 The Compilation Pipeline
 
 <div style="text-align: center; margin: 2em 0;">
 <svg width="500" height="180" viewBox="0 0 500 180" xmlns="http://www.w3.org/2000/svg">  <!-- Row 1 -->  <!-- Discovery -->  <rect x="10" y="20" width="70" height="45" rx="4" fill="#f3e8ff" stroke="#a855f7" stroke-width="2"/>  <text x="45" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#7c3aed">DISCOVER</text>  <text x="45" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#9333ea">.aro files</text>  <!-- Arrow -->  <line x1="80" y1="42" x2="95" y2="42" stroke="#9ca3af" stroke-width="1.5"/>  <polygon points="95,42 89,38 89,46" fill="#9ca3af"/>  <!-- Parse -->  <rect x="100" y="20" width="70" height="45" rx="4" fill="#dbeafe" stroke="#3b82f6" stroke-width="2"/>  <text x="135" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#1e40af">PARSE</text>  <text x="135" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#3b82f6">→ AST</text>  <!-- Arrow -->  <line x1="170" y1="42" x2="185" y2="42" stroke="#9ca3af" stroke-width="1.5"/>  <polygon points="185,42 179,38 179,46" fill="#9ca3af"/>  <!-- Semantic -->  <rect x="190" y="20" width="70" height="45" rx="4" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>  <text x="225" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#166534">ANALYZE</text>  <text x="225" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#22c55e">semantics</text>  <!-- Arrow -->  <line x1="260" y1="42" x2="275" y2="42" stroke="#9ca3af" stroke-width="1.5"/>  <polygon points="275,42 269,38 269,46" fill="#9ca3af"/>  <!-- Code Gen -->  <rect x="280" y="20" width="70" height="45" rx="4" fill="#fef3c7" stroke="#f59e0b" stroke-width="2"/>  <text x="315" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#92400e">GENERATE</text>  <text x="315" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#f59e0b">→ LLVM IR</text>  <!-- Arrow -->  <line x1="350" y1="42" x2="365" y2="42" stroke="#9ca3af" stroke-width="1.5"/>  <polygon points="365,42 359,38 359,46" fill="#9ca3af"/>  <!-- Compile -->  <rect x="370" y="20" width="55" height="45" rx="4" fill="#fee2e2" stroke="#ef4444" stroke-width="2"/>  <text x="397" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#991b1b">COMPILE</text>  <text x="397" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#ef4444">llc</text>  <!-- Arrow -->  <line x1="425" y1="42" x2="440" y2="42" stroke="#9ca3af" stroke-width="1.5"/>  <polygon points="440,42 434,38 434,46" fill="#9ca3af"/>  <!-- Link -->  <rect x="445" y="20" width="45" height="45" rx="4" fill="#1f2937" stroke="#1f2937" stroke-width="2"/>  <text x="467" y="38" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#ffffff">LINK</text>  <text x="467" y="52" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#9ca3af">binary</text>  <!-- Bottom: File representations -->  <text x="45" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">*.aro</text>  <text x="135" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">AST</text>  <text x="225" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">validated</text>  <text x="315" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">*.ll</text>  <text x="397" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">*.o</text>  <text x="467" y="85" text-anchor="middle" font-family="monospace" font-size="8" fill="#6b7280">MyApp</text>  <!-- Runtime library connection -->  <rect x="370" y="110" width="120" height="35" rx="4" fill="#e0e7ff" stroke="#6366f1" stroke-width="1" stroke-dasharray="4,2"/>  <text x="430" y="125" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#4338ca">ARO Runtime Library</text>  <text x="430" y="138" text-anchor="middle" font-family="monospace" font-size="8" fill="#6366f1">libaro.a</text>  <!-- Dashed line to Link -->  <line x1="430" y1="110" x2="467" y2="65" stroke="#6366f1" stroke-width="1" stroke-dasharray="3,2"/></svg>
@@ -52,7 +52,7 @@ Linking combines the object code with the ARO runtime library to produce the fin
 
 ---
 
-## 19.4 Runtime Requirements
+## 22.4 Runtime Requirements
 
 Native binaries link against the ARO runtime library, which provides implementations of actions and services. This library is included in every binary.
 
@@ -64,7 +64,7 @@ Dynamically loaded plugins are not supported in native builds. All actions must 
 
 ---
 
-## 19.5 Binary Size and Performance
+## 22.5 Binary Size and Performance
 
 Native binaries have characteristic size and performance profiles that differ from interpreted execution.
 
@@ -78,7 +78,7 @@ Memory usage is typically lower for native binaries because they do not maintain
 
 ---
 
-## 19.6 Deployment
+## 22.6 Deployment
 
 Native binaries simplify deployment because they have minimal runtime dependencies. The binary, the OpenAPI specification (if using HTTP), and any data files are all you need to deploy.
 
@@ -90,7 +90,7 @@ Cloud deployment to platforms that accept binaries—EC2, GCE, bare metal—is s
 
 ---
 
-## 19.7 Debugging
+## 22.7 Debugging
 
 Debugging native binaries requires different tools than debugging interpreted execution. The runtime's verbose output is not available; instead, you use traditional native debugging tools.
 
@@ -104,7 +104,7 @@ Logging becomes more important when detailed runtime output is not available. In
 
 ---
 
-## 19.8 Output Formatting
+## 22.8 Output Formatting
 
 Native binaries produce cleaner output than interpreted execution. This difference is intentional and reflects the different contexts in which each mode is used.
 
@@ -130,7 +130,7 @@ Response formatting remains unchanged between modes. The `[OK]` status prefix an
 
 ---
 
-## 19.9 Development Workflow
+## 22.9 Development Workflow
 
 Development typically uses interpreted execution for rapid iteration. The interpreted mode has faster turnaround—you change code and immediately run the updated version without a compile step. Verbose output shows what the runtime does, aiding debugging and understanding.
 
@@ -142,7 +142,7 @@ Release processes should produce native binaries with release optimizations. Tag
 
 ---
 
-## 19.10 Limitations
+## 22.10 Limitations
 
 Native compilation has limitations compared to interpreted execution.
 
@@ -156,7 +156,7 @@ The compilation step adds time to the development cycle. For rapid iteration, th
 
 ---
 
-## 19.11 Best Practices
+## 22.11 Best Practices
 
 Use interpreted mode during development for fast iteration and detailed diagnostics. Switch to native compilation for deployment testing and release.
 
@@ -170,4 +170,4 @@ Deploy the OpenAPI specification and other required files alongside the binary. 
 
 ---
 
-*Next: Chapter 20 — Multi-file Applications*
+*Next: Chapter 23 — Multi-file Applications*

--- a/Book/TheLanguageGuide/Chapter23-MultiFile.md
+++ b/Book/TheLanguageGuide/Chapter23-MultiFile.md
@@ -1,10 +1,10 @@
-# Chapter 20: Multi-file Applications
+# Chapter 23: Multi-file Applications
 
 *"Organize by domain, not by technical layer."*
 
 ---
 
-## 20.1 Application Structure
+## 23.1 Application Structure
 
 An ARO application is a directory containing source files, configuration, and optional auxiliary files. The runtime automatically discovers all ARO source files in this directory and its subdirectories, compiling them together into a unified application.
 
@@ -16,7 +16,7 @@ Certain files have special significance. The openapi.yaml file, if present, defi
 
 ---
 
-## 20.2 Auto-Discovery
+## 23.2 Auto-Discovery
 
 When you run an ARO application, the runtime scans the application directory recursively for files with the .aro extension. Each file is parsed, and its feature sets are registered. This happens automatically without any configuration.
 
@@ -28,7 +28,7 @@ The discovery process validates structural requirements. It checks that exactly 
 
 ---
 
-## 20.3 Global Visibility
+## 23.3 Global Visibility
 
 Feature sets are globally visible without imports. This is a fundamental design choice that enables loose coupling through events.
 
@@ -42,7 +42,7 @@ Repositories are implicitly shared. When one feature set stores data to a reposi
 
 ---
 
-## 20.4 The Application-Start Requirement
+## 23.4 The Application-Start Requirement
 
 Every ARO application must have exactly one Application-Start feature set. This requirement ensures there is an unambiguous entry point for execution.
 
@@ -56,7 +56,7 @@ The Application-End feature sets (Success and Error variants) have similar const
 
 ---
 
-## 20.5 Organization Strategies
+## 23.5 Organization Strategies
 
 Several strategies for organizing multi-file applications have proven effective in practice.
 
@@ -163,7 +163,7 @@ Key points in this layout:
 
 ---
 
-## 20.6 Recommended Patterns
+## 23.6 Recommended Patterns
 
 Experience suggests some patterns that work well across different types of applications.
 
@@ -177,7 +177,7 @@ Use descriptive file names that indicate content. A file named users.aro clearly
 
 ---
 
-## 20.7 Sharing Data Between Files
+## 23.7 Sharing Data Between Files
 
 Feature sets in different files can share data through several mechanisms, each appropriate for different scenarios.
 
@@ -191,7 +191,7 @@ The choice between these mechanisms depends on the relationship between the shar
 
 ---
 
-## 20.8 Best Practices
+## 23.8 Best Practices
 
 Establish naming conventions early and follow them consistently. File names, feature set names, event names, and repository names should follow predictable patterns that team members can learn and apply.
 
@@ -205,4 +205,4 @@ Test files can follow the same organization as production code. Test files for u
 
 ---
 
-*Next: Chapter 21 — Patterns & Practices*
+*Next: Chapter 24 — Patterns & Practices*

--- a/Book/TheLanguageGuide/Chapter24-Patterns.md
+++ b/Book/TheLanguageGuide/Chapter24-Patterns.md
@@ -1,10 +1,10 @@
-# Chapter 21: Patterns & Practices
+# Chapter 24: Patterns & Practices
 
 *"Good patterns emerge from solving real problems."*
 
 ---
 
-## 21.1 CRUD Patterns
+## 24.1 CRUD Patterns
 
 Most business applications need to create, read, update, and delete resources. These CRUD operations follow predictable patterns in ARO that you can apply consistently across your domains.
 
@@ -22,7 +22,7 @@ The delete operation extracts the identifier, deletes the matching record, emits
 
 ---
 
-## 21.2 Event Sourcing
+## 24.2 Event Sourcing
 
 Event sourcing stores the history of changes rather than current state. Instead of updating a record in place, you append an event describing what happened. Current state is computed by replaying events from the beginning.
 
@@ -38,7 +38,7 @@ Event sourcing adds complexity compared to simple CRUD. It is most valuable when
 
 ---
 
-## 21.3 The Saga Pattern
+## 24.3 The Saga Pattern
 
 <div style="float: left; margin: 0 1.5em 1em 0;">
 <svg width="160" height="180" viewBox="0 0 160 180" xmlns="http://www.w3.org/2000/svg">  <!-- Title -->  <text x="80" y="15" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#166534">Saga Flow</text>  <!-- Step 1 -->  <rect x="50" y="25" width="60" height="22" rx="3" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>  <text x="80" y="40" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#166534">Step 1</text>  <line x1="80" y1="47" x2="80" y2="57" stroke="#22c55e" stroke-width="1.5"/>  <polygon points="80,57 76,52 84,52" fill="#22c55e"/>  <!-- Step 2 -->  <rect x="50" y="60" width="60" height="22" rx="3" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>  <text x="80" y="75" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#166534">Step 2</text>  <line x1="80" y1="82" x2="80" y2="92" stroke="#22c55e" stroke-width="1.5"/>  <polygon points="80,92 76,87 84,87" fill="#22c55e"/>  <!-- Step 3 (fails) -->  <rect x="50" y="95" width="60" height="22" rx="3" fill="#fee2e2" stroke="#ef4444" stroke-width="1.5"/>  <text x="80" y="110" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#991b1b">Step 3 ✗</text>  <!-- Compensation arrows -->  <line x1="50" y1="106" x2="25" y2="106" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,2"/>  <line x1="25" y1="106" x2="25" y2="40" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,2"/>  <polygon points="25,40 21,46 29,46" fill="#ef4444"/>  <!-- Compensation boxes -->  <rect x="5" y="125" width="45" height="18" rx="2" fill="#fef3c7" stroke="#f59e0b" stroke-width="1"/>  <text x="27" y="137" text-anchor="middle" font-family="sans-serif" font-size="6" fill="#92400e">undo 2</text>  <rect x="55" y="125" width="45" height="18" rx="2" fill="#fef3c7" stroke="#f59e0b" stroke-width="1"/>  <text x="77" y="137" text-anchor="middle" font-family="sans-serif" font-size="6" fill="#92400e">undo 1</text>  <!-- Labels -->  <text x="80" y="158" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#9ca3af">compensate on failure</text></svg>
@@ -58,7 +58,7 @@ Use sagas when you need to coordinate actions across multiple services or when s
 
 ---
 
-## 21.4 The Gateway Pattern
+## 24.4 The Gateway Pattern
 
 API gateways aggregate data from multiple backend services into unified responses. Rather than having clients make multiple calls and combine results, the gateway handles this coordination.
 
@@ -72,7 +72,7 @@ The gateway pattern can also handle cross-cutting concerns like authentication, 
 
 ---
 
-## 21.5 Command Query Responsibility Segregation
+## 24.5 Command Query Responsibility Segregation
 
 <div style="float: right; margin: 0 0 1em 1.5em;">
 <svg width="180" height="160" viewBox="0 0 180 160" xmlns="http://www.w3.org/2000/svg">  <!-- Title -->  <text x="90" y="15" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#374151">CQRS</text>  <!-- Command side -->  <rect x="10" y="30" width="70" height="25" rx="3" fill="#fee2e2" stroke="#ef4444" stroke-width="1.5"/>  <text x="45" y="46" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#991b1b">Commands</text>  <line x1="45" y1="55" x2="45" y2="75" stroke="#ef4444" stroke-width="1.5"/>  <polygon points="45,75 40,68 50,68" fill="#ef4444"/>  <rect x="10" y="80" width="70" height="25" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>  <text x="45" y="96" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#92400e">Write Store</text>  <!-- Query side -->  <rect x="100" y="30" width="70" height="25" rx="3" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>  <text x="135" y="46" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#1e40af">Queries</text>  <line x1="135" y1="55" x2="135" y2="75" stroke="#3b82f6" stroke-width="1.5"/>  <polygon points="135,75 130,68 140,68" fill="#3b82f6"/>  <rect x="100" y="80" width="70" height="25" rx="3" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>  <text x="135" y="96" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#166534">Read Model</text>  <!-- Sync arrow -->  <line x1="80" y1="92" x2="100" y2="92" stroke="#9ca3af" stroke-width="1" stroke-dasharray="3,2"/>  <polygon points="100,92 95,89 95,95" fill="#9ca3af"/>  <text x="90" y="118" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#9ca3af">events sync</text>  <!-- Labels -->  <text x="45" y="140" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#ef4444">consistency</text>  <text x="135" y="140" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#3b82f6">optimized</text></svg>
@@ -90,7 +90,7 @@ CQRS adds complexity because you maintain multiple representations of data that 
 
 ---
 
-## 21.6 Error Handling Patterns
+## 24.6 Error Handling Patterns
 
 ARO's happy path philosophy means you do not write explicit error handling, but you can still respond to errors through event-driven patterns.
 
@@ -104,7 +104,7 @@ Circuit breaker patterns can protect against cascading failures when backend ser
 
 ---
 
-## 21.7 Security Patterns
+## 24.7 Security Patterns
 
 Authentication verifies caller identity. Security-sensitive endpoints extract authentication tokens, validate them against an authentication service, and extract identity claims. Subsequent operations use the validated identity.
 
@@ -118,7 +118,7 @@ These patterns compose together. A secured endpoint might extract and validate a
 
 ---
 
-## 21.8 Performance Patterns
+## 24.8 Performance Patterns
 
 Caching reduces load on backend services by storing frequently accessed data. A cache-aware handler first checks the cache. On cache hit, it returns immediately. On cache miss, it fetches from the source, stores in the cache, and returns. Time-to-live settings control cache freshness.
 
@@ -132,7 +132,7 @@ Pagination prevents unbounded result sets. List operations return limited pages 
 
 ---
 
-## 21.9 Best Practices Summary
+## 24.9 Best Practices Summary
 
 These practices have emerged from experience building ARO applications and reflect lessons learned about what works well.
 
@@ -158,4 +158,4 @@ Document the non-obvious. Code should be self-documenting for basic behavior. Co
 
 ---
 
-*Next: Chapter 22 — State Machines*
+*Next: Chapter 25 — State Machines*

--- a/Book/TheLanguageGuide/Chapter25-StateMachines.md
+++ b/Book/TheLanguageGuide/Chapter25-StateMachines.md
@@ -1,10 +1,10 @@
-# Chapter 22: State Machines
+# Chapter 25: State Machines
 
 *"A business object is only as valid as its current state."*
 
 ---
 
-## 22.1 Why State Machines Matter
+## 25.1 Why State Machines Matter
 
 Business entities rarely exist in a single state. An order is drafted, placed, paid, shipped, and delivered. A support ticket is opened, assigned, escalated, and resolved. A document is drafted, reviewed, approved, and published. These lifecycles define what operations are valid at each point in time.
 
@@ -14,7 +14,7 @@ State machines make lifecycles explicit. They define what states exist, what tra
 
 ---
 
-## 22.2 ARO's Approach to State
+## 25.2 ARO's Approach to State
 
 ARO takes a deliberately simple approach to state machines. There is no state machine library, no visual editor, no hierarchical states. Instead, ARO provides a single action—`Accept`—that validates and applies state transitions within your existing feature sets.
 
@@ -24,7 +24,7 @@ States in ARO are defined as OpenAPI enum types. This means your API contract do
 
 ---
 
-## 22.3 Defining States in OpenAPI
+## 25.3 Defining States in OpenAPI
 
 States are defined as string enums in your OpenAPI specification. Here is how an order lifecycle might be defined:
 
@@ -67,7 +67,7 @@ This creates a clear contract: orders have a status field that must be one of th
 
 ---
 
-## 22.4 The Accept Action
+## 25.4 The Accept Action
 
 <div style="float: right; margin: 0 0 1em 1.5em;">
 <svg width="180" height="200" viewBox="0 0 180 200" xmlns="http://www.w3.org/2000/svg">
@@ -138,7 +138,7 @@ If the order's status is not `"draft"`, execution stops with an error. The calle
 
 ---
 
-## 22.5 State Transition Validation
+## 25.5 State Transition Validation
 
 The Accept action provides clear error messages when transitions fail. If you attempt to place an order that has already been paid:
 
@@ -154,7 +154,7 @@ Consider what this means for debugging. When a user reports "I can't place my or
 
 ---
 
-## 22.6 Complete Example: Order Lifecycle
+## 25.6 Complete Example: Order Lifecycle
 
 <div style="float: left; margin: 0 1.5em 1em 0;">
 <svg width="140" height="280" viewBox="0 0 140 280" xmlns="http://www.w3.org/2000/svg">
@@ -327,7 +327,7 @@ Each feature set retrieves the order, validates and applies its transition, stor
 
 ---
 
-## 22.7 Cancellation Paths
+## 25.7 Cancellation Paths
 
 Real business processes have more than one terminal state. Orders can be cancelled as well as delivered. The state machine must define which transitions lead to cancellation.
 
@@ -394,7 +394,7 @@ The choice depends on whether the different cancellation paths have different si
 
 ---
 
-## 22.8 What ARO Does Not Do
+## 25.8 What ARO Does Not Do
 
 ARO's state machine approach is deliberately minimal. Understanding what it does not do helps you decide when simpler approaches suffice and when you need external tooling.
 
@@ -412,7 +412,7 @@ These limitations are features, not bugs. They keep the language simple. For mos
 
 ---
 
-## 22.9 Combining States with Events
+## 25.9 Combining States with Events
 
 State transitions naturally pair with events. When an order moves to a new state, other parts of the system often need to react. Shipping needs to know when orders are paid. Notifications need to know when orders are delivered.
 
@@ -489,7 +489,7 @@ State guards enable guaranteed ordering through state-based filtering. Instead o
 
 ---
 
-## 22.10 Best Practices
+## 25.10 Best Practices
 
 **Define all states in OpenAPI.** The contract should be the source of truth for what states exist. Clients and tooling can use this information.
 
@@ -507,4 +507,4 @@ State guards enable guaranteed ordering through state-based filtering. Instead o
 
 ---
 
-*Next: Chapter 23 — Modules and Imports*
+*Next: Chapter 26 — Modules and Imports*

--- a/Book/TheLanguageGuide/Chapter26-Modules.md
+++ b/Book/TheLanguageGuide/Chapter26-Modules.md
@@ -1,10 +1,10 @@
-# Chapter 23: Modules and Imports
+# Chapter 26: Modules and Imports
 
 *"Compose applications from small, understandable pieces."*
 
 ---
 
-## 23.1 Application Composition
+## 26.1 Application Composition
 
 <div style="text-align: center; margin: 2em 0;">
 <svg width="400" height="140" viewBox="0 0 400 140" xmlns="http://www.w3.org/2000/svg">  <!-- Module A -->  <rect x="30" y="20" width="100" height="50" rx="5" fill="#dbeafe" stroke="#3b82f6" stroke-width="2"/>  <text x="80" y="40" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#1e40af">Module A</text>  <text x="80" y="55" text-anchor="middle" font-family="monospace" font-size="8" fill="#3b82f6">/module-a</text>  <!-- Module B -->  <rect x="270" y="20" width="100" height="50" rx="5" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>  <text x="320" y="40" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#166534">Module B</text>  <text x="320" y="55" text-anchor="middle" font-family="monospace" font-size="8" fill="#22c55e">/module-b</text>  <!-- Arrows -->  <line x1="80" y1="70" x2="160" y2="100" stroke="#6b7280" stroke-width="2"/>  <polygon points="160,100 152,95 152,105" fill="#6b7280"/>  <line x1="320" y1="70" x2="240" y2="100" stroke="#6b7280" stroke-width="2"/>  <polygon points="240,100 248,95 248,105" fill="#6b7280"/>  <!-- Combined -->  <rect x="150" y="100" width="100" height="35" rx="5" fill="#e0e7ff" stroke="#6366f1" stroke-width="2"/>  <text x="200" y="118" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#4338ca">Combined</text>  <text x="200" y="130" text-anchor="middle" font-family="monospace" font-size="7" fill="#6366f1">import ../A ../B</text>  <!-- Labels -->  <text x="115" y="85" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#9ca3af">import</text>  <text x="285" y="85" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#9ca3af">import</text></svg>
@@ -18,7 +18,7 @@ This design reflects how project managers think about systems. Applications are 
 
 ---
 
-## 23.2 Import Syntax
+## 26.2 Import Syntax
 
 The import statement appears at the top of an ARO file, before any feature sets:
 
@@ -42,7 +42,7 @@ There is no need to specify what you want from the imported application. Everyth
 
 ---
 
-## 23.3 No Visibility Modifiers
+## 26.3 No Visibility Modifiers
 
 ARO explicitly rejects visibility modifiers. There is no `public`, `private`, or `internal`.
 
@@ -61,7 +61,7 @@ When you import an application, you are saying: I want this application's capabi
 
 ---
 
-## 23.4 The ModulesExample
+## 26.4 The ModulesExample
 
 The `Examples/ModulesExample` directory demonstrates application composition with three directories:
 
@@ -152,7 +152,7 @@ The `getModuleA` and `getModuleB` feature sets come from the imported applicatio
 
 ---
 
-## 23.5 Building Standalone Binaries
+## 26.5 Building Standalone Binaries
 
 Each module produces its own standalone binary:
 
@@ -174,7 +174,7 @@ The Combined binary includes all code from both imported modules. The resulting 
 
 ---
 
-## 23.6 Distributed Services Pattern
+## 26.6 Distributed Services Pattern
 
 <div style="float: right; margin: 0 0 1em 1.5em;">
 <svg width="160" height="200" viewBox="0 0 160 200" xmlns="http://www.w3.org/2000/svg">  <!-- Auth -->  <rect x="10" y="10" width="60" height="35" rx="4" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>  <text x="40" y="28" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#1e40af">Auth</text>  <text x="40" y="40" text-anchor="middle" font-family="monospace" font-size="6" fill="#3b82f6">:8081</text>  <!-- Users -->  <rect x="90" y="10" width="60" height="35" rx="4" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>  <text x="120" y="28" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#166534">Users</text>  <text x="120" y="40" text-anchor="middle" font-family="monospace" font-size="6" fill="#22c55e">:8082</text>  <!-- Orders -->  <rect x="10" y="60" width="60" height="35" rx="4" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>  <text x="40" y="78" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#92400e">Orders</text>  <text x="40" y="90" text-anchor="middle" font-family="monospace" font-size="6" fill="#f59e0b">:8083</text>  <!-- Payments -->  <rect x="90" y="60" width="60" height="35" rx="4" fill="#f3e8ff" stroke="#a855f7" stroke-width="1.5"/>  <text x="120" y="78" text-anchor="middle" font-family="sans-serif" font-size="8" font-weight="bold" fill="#7c3aed">Payments</text>  <text x="120" y="90" text-anchor="middle" font-family="monospace" font-size="6" fill="#a855f7">:8084</text>  <!-- Arrows to gateway -->  <line x1="40" y1="45" x2="70" y2="130" stroke="#6b7280" stroke-width="1"/>  <line x1="120" y1="45" x2="90" y2="130" stroke="#6b7280" stroke-width="1"/>  <line x1="40" y1="95" x2="70" y2="130" stroke="#6b7280" stroke-width="1"/>  <line x1="120" y1="95" x2="90" y2="130" stroke="#6b7280" stroke-width="1"/>  <!-- Gateway -->  <rect x="35" y="130" width="90" height="40" rx="4" fill="#e0e7ff" stroke="#6366f1" stroke-width="2"/>  <text x="80" y="150" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="bold" fill="#4338ca">Gateway</text>  <text x="80" y="163" text-anchor="middle" font-family="monospace" font-size="7" fill="#6366f1">:8080</text>  <!-- Label -->  <text x="80" y="190" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#9ca3af">imports all services</text></svg>
@@ -204,7 +204,7 @@ For development, you might run the gateway monolith. For production, you might r
 
 ---
 
-## 23.7 Sharing Data Between Applications
+## 26.7 Sharing Data Between Applications
 
 When you import an application, you get access to its published variables within the same business activity. The Publish action (see ARO-0003) makes values available to feature sets sharing that business activity:
 
@@ -233,7 +233,7 @@ import ../auth-service
 
 ---
 
-## 23.8 What Is Not Imported
+## 26.8 What Is Not Imported
 
 When you import an application, its Application-Start feature set is not executed. Only the importing application's Application-Start runs. The imported feature sets become available, but lifecycle management remains with the importing application.
 
@@ -243,7 +243,7 @@ Similarly, Application-End handlers from imported applications are not triggered
 
 ---
 
-## 23.9 Circular Imports
+## 26.9 Circular Imports
 
 Circular imports are technically allowed:
 
@@ -265,7 +265,7 @@ However, circular dependencies usually indicate poor architecture. If two applic
 
 ---
 
-## 23.10 What Is Not Provided
+## 26.10 What Is Not Provided
 
 ARO deliberately omits many features found in other module systems:
 
@@ -281,7 +281,7 @@ These are implementation concerns that add complexity without matching how ARO a
 
 ---
 
-## 23.11 Summary
+## 26.11 Summary
 
 The import system embodies ARO's philosophy of simplicity:
 
@@ -295,4 +295,4 @@ This is not enterprise-grade module management. It is application composition fo
 
 ---
 
-*Next: Chapter 24 — Control Flow*
+*Next: Chapter 27 — Control Flow*

--- a/Book/TheLanguageGuide/Chapter27-ControlFlow.md
+++ b/Book/TheLanguageGuide/Chapter27-ControlFlow.md
@@ -1,4 +1,4 @@
-# Chapter 24: Control Flow
+# Chapter 27: Control Flow
 
 ARO provides control flow constructs for conditional execution. This chapter covers how to make decisions in your feature sets using guarded statements and match expressions.
 
@@ -453,4 +453,4 @@ match <order: status> {
 
 ---
 
-*Next: Chapter 25 — Data Pipelines*
+*Next: Chapter 28 — Data Pipelines*

--- a/Book/TheLanguageGuide/Chapter28-DataPipelines.md
+++ b/Book/TheLanguageGuide/Chapter28-DataPipelines.md
@@ -1,4 +1,4 @@
-# Chapter 25: Data Pipelines
+# Chapter 28: Data Pipelines
 
 ARO provides a map/reduce style data pipeline for filtering, transforming, and aggregating collections. All operations are type-safe, with results typed via OpenAPI schemas.
 
@@ -382,4 +382,4 @@ For complex data needs, use multiple feature sets and compose results in your bu
 
 ---
 
-*Next: Chapter 26 — Repositories*
+*Next: Chapter 29 — Repositories*

--- a/Book/TheLanguageGuide/Chapter29-Repositories.md
+++ b/Book/TheLanguageGuide/Chapter29-Repositories.md
@@ -1,4 +1,4 @@
-# Chapter 26: Repositories
+# Chapter 29: Repositories
 
 Repositories provide persistent in-memory storage that survives across HTTP requests and event handlers. Unlike regular variables which are scoped to a single feature set execution, repositories maintain state for the lifetime of the application.
 
@@ -437,4 +437,4 @@ Store simple, serializable data:
 
 ---
 
-*Next: Chapter 27 — System Commands*
+*Next: Chapter 30 — System Commands*

--- a/Book/TheLanguageGuide/Chapter30-SystemCommands.md
+++ b/Book/TheLanguageGuide/Chapter30-SystemCommands.md
@@ -1,4 +1,4 @@
-# Chapter 27: System Commands
+# Chapter 30: System Commands
 
 ARO provides the `<Exec>` action for executing shell commands on the host system. This chapter covers command execution, result handling, and security considerations.
 
@@ -293,4 +293,4 @@ Future versions may support sandboxing options:
 
 ---
 
-*Next: Chapter 28 — HTTP Client*
+*Next: Chapter 31 — HTTP Client*

--- a/Book/TheLanguageGuide/Chapter31-HTTPClient.md
+++ b/Book/TheLanguageGuide/Chapter31-HTTPClient.md
@@ -1,4 +1,4 @@
-# Chapter 28: HTTP Client
+# Chapter 31: HTTP Client
 
 ARO provides HTTP client capabilities for making requests to external services and APIs.
 
@@ -127,4 +127,4 @@ The `<Request>` action automatically parses JSON responses. After a request, the
 
 ---
 
-*Next: Chapter 29 — Concurrency*
+*Next: Chapter 32 — Concurrency*

--- a/Book/TheLanguageGuide/Chapter32-Concurrency.md
+++ b/Book/TheLanguageGuide/Chapter32-Concurrency.md
@@ -1,4 +1,4 @@
-# Chapter 29: Concurrency
+# Chapter 32: Concurrency
 
 ARO's concurrency model is radically simple: **feature sets are async, statements are sync**. This chapter explains how ARO handles concurrent operations without requiring you to think about threads, locks, or async/await.
 
@@ -247,4 +247,4 @@ Write synchronous code. Get async performance. No callbacks, no promises, no awa
 
 ---
 
-*Next: Chapter 30 — Context-Aware Response Formatting*
+*Next: Chapter 33 — Context-Aware Response Formatting*

--- a/Book/TheLanguageGuide/Chapter33-ContextResponses.md
+++ b/Book/TheLanguageGuide/Chapter33-ContextResponses.md
@@ -1,4 +1,4 @@
-# Chapter 30: Context-Aware Response Formatting
+# Chapter 33: Context-Aware Response Formatting
 
 ARO automatically formats responses and log output based on the execution context. The same code produces different output formats depending on how it's invoked.
 
@@ -143,4 +143,4 @@ The `<Return>` action sets the response, which is formatted based on context:
 
 ---
 
-*Next: Chapter 31 — Type System*
+*Next: Chapter 34 — Type System*

--- a/Book/TheLanguageGuide/Chapter34-TypeSystem.md
+++ b/Book/TheLanguageGuide/Chapter34-TypeSystem.md
@@ -1,4 +1,4 @@
-# Chapter 31: Type System
+# Chapter 34: Type System
 
 ARO has a simple type system: four built-in primitives, two collection types, and complex types defined externally in OpenAPI. This chapter explains how types work in ARO.
 
@@ -258,4 +258,4 @@ components:
 
 ---
 
-*Next: Appendix A — Action Reference*
+*Next: Chapter 35 — Date and Time*

--- a/Book/TheLanguageGuide/Chapter35-Dates.md
+++ b/Book/TheLanguageGuide/Chapter35-Dates.md
@@ -1,10 +1,10 @@
-# Chapter 32: Date and Time
+# Chapter 35: Date and Time
 
 *"Time is the fire in which we burn."*
 
 ---
 
-## 32.1 The Nature of Time in ARO
+## 35.1 The Nature of Time in ARO
 
 Time is a fundamental dimension of business logic. Orders have timestamps. Contracts have deadlines. Meetings have schedules. Reports have periods. Almost every business domain involves temporal reasoning in some form.
 
@@ -14,7 +14,7 @@ The foundation of ARO's temporal model is UTC (Coordinated Universal Time). All 
 
 ---
 
-## 32.2 The Magic `<now>` Variable
+## 35.2 The Magic `<now>` Variable
 
 ARO provides a special variable that exists without declaration: `<now>`. This magic variable always resolves to the current UTC timestamp:
 
@@ -37,7 +37,7 @@ Unlike regular variables, `<now>` needs no prior binding. It exists in every fea
 
 ---
 
-## 32.3 Extracting Date Components
+## 35.3 Extracting Date Components
 
 Dates contain structured information: years, months, days, hours, minutes, seconds. ARO exposes these components through qualifiers:
 
@@ -92,7 +92,7 @@ Additional properties include `timestamp` (Unix epoch seconds), `iso` (the full 
 
 ---
 
-## 32.4 Parsing Date Strings
+## 35.4 Parsing Date Strings
 
 External systems send dates as strings. Users enter dates in forms. Configuration files specify dates in text. ARO parses these into proper date objects:
 
@@ -113,7 +113,7 @@ The parser is strict. Invalid dates produce errors rather than surprising interp
 
 ---
 
-## 32.5 Formatting Dates
+## 35.5 Formatting Dates
 
 Dates need to be displayed to users, and different contexts call for different formats. Europeans expect day-month-year. Americans expect month-day-year. Formal documents want full month names. Log files want compact timestamps.
 
@@ -136,7 +136,7 @@ The pattern language follows standard conventions. Four `y`s mean four-digit yea
 
 ---
 
-## 32.6 Relative Offsets
+## 35.6 Relative Offsets
 
 Business logic often involves relative dates. "Tomorrow" is one day from now. "Next week" is seven days from now. "The booking expires in 24 hours." These relative calculations are expressed through offset qualifiers:
 
@@ -168,7 +168,7 @@ Offsets can be chained by computing from an already-offset date:
 
 ---
 
-## 32.7 Date Ranges
+## 35.7 Date Ranges
 
 Many business concepts span periods: fiscal quarters, subscription terms, booking windows, sale periods. ARO represents these as date ranges:
 
@@ -195,7 +195,7 @@ when <order-date> in <sale-period> {
 
 ---
 
-## 32.8 Date Comparisons
+## 35.8 Date Comparisons
 
 Dates can be compared using `before` and `after` operators in when clauses:
 
@@ -213,7 +213,7 @@ These temporal comparisons read naturally and express intent clearly. The runtim
 
 ---
 
-## 32.9 Distance Between Dates
+## 35.9 Distance Between Dates
 
 How many days until the deadline? How many hours since the last update? These questions require calculating the distance between two dates:
 
@@ -227,7 +227,7 @@ The distance operation captures the interval between two points in time. You can
 
 ---
 
-## 32.10 Recurrence Patterns
+## 35.10 Recurrence Patterns
 
 Some events repeat: weekly meetings, monthly reports, annual reviews. ARO supports recurrence patterns:
 
@@ -253,7 +253,7 @@ Supported patterns include:
 
 ---
 
-## 32.11 Design Philosophy
+## 35.11 Design Philosophy
 
 ARO's date handling embodies several principles:
 
@@ -269,7 +269,7 @@ ARO's date handling embodies several principles:
 
 ---
 
-## 32.12 Summary
+## 35.12 Summary
 
 Time handling in ARO provides:
 
@@ -284,3 +284,7 @@ Time handling in ARO provides:
 - **Recurrence**: Define repeating patterns
 
 With these tools, ARO handles the temporal dimension of business logic clearly and consistently.
+
+---
+
+*Next: Appendix A — Action Reference*

--- a/Book/TheLanguageGuide/STRUCTURE.md
+++ b/Book/TheLanguageGuide/STRUCTURE.md
@@ -9,44 +9,45 @@
 4. **Anatomy of a Statement** — `<Action> the <Result> preposition the <Object>`
 5. **Feature Sets** — Naming, business activities, scoping
 6. **Data Flow** — Semantic roles (REQUEST, OWN, RESPONSE, EXPORT)
-6A. **Export Actions** — Choosing between Store, Emit, and Publish
-7. **Computations** — Transform and compute data with built-in operations
-8. **Understanding Qualifiers** — Operation selectors vs field navigation
-9. **The Happy Path** — Why there's no error handling (and why that's okay)
+7. **Export Actions** — Choosing between Store, Emit, and Publish
+8. **Computations** — Transform and compute data with built-in operations
+9. **Understanding Qualifiers** — Operation selectors vs field navigation
+10. **The Happy Path** — Why there's no error handling (and why that's okay)
 
 ## Part III: Event-Driven Architecture
-10. **The Event Bus** — How feature sets get triggered
-11. **Application Lifecycle** — Start, End, Keepalive
-12. **Custom Events** — Emit, handlers, event-driven design
+11. **The Event Bus** — How feature sets get triggered
+12. **Application Lifecycle** — Start, End, Keepalive
+13. **Custom Events** — Emit, handlers, event-driven design
 
 ## Part IV: Contract-First APIs
-13. **OpenAPI Integration** — Your contract is your router
-14. **HTTP Feature Sets** — operationId as feature set name
-15. **Request/Response Patterns** — Extract, Return, path parameters
+14. **OpenAPI Integration** — Your contract is your router
+15. **HTTP Feature Sets** — operationId as feature set name
+16. **Request/Response Patterns** — Extract, Return, path parameters
 
 ## Part V: Services & Extensions
-16. **Built-in Services** — HTTP, files, sockets
-16B. **Format-Aware File I/O** — Automatic serialization by file extension
-17. **Custom Actions** — Adding new verbs to ARO
-17B. **Custom Services** — External integrations via Call action
-18. **Plugins** — Packaging and distributing extensions
+17. **Built-in Services** — HTTP, files, sockets
+18. **Format-Aware File I/O** — Automatic serialization by file extension
+19. **Custom Actions** — Adding new verbs to ARO
+20. **Custom Services** — External integrations via Call action
+21. **Plugins** — Packaging and distributing extensions
 
 ## Part VI: Production
-19. **Native Compilation** — `aro build` and the C runtime
-20. **Multi-file Applications** — Project structure
-21. **Patterns & Practices** — Real-world architectures
-22. **State Machines** — Lifecycle management with the Accept action
-23. **Modules and Imports** — Modular architecture and cross-module visibility
+22. **Native Compilation** — `aro build` and the C runtime
+23. **Multi-file Applications** — Project structure
+24. **Patterns & Practices** — Real-world architectures
+25. **State Machines** — Lifecycle management with the Accept action
+26. **Modules and Imports** — Modular architecture and cross-module visibility
 
 ## Part VII: Advanced Topics
-24. **Control Flow** — Guards, match expressions, conditional execution
-25. **Data Pipelines** — Map, Filter, Reduce for collection processing
-26. **Repositories** — Persistent in-memory storage and observers
-27. **System Commands** — Shell execution with the Exec action
-28. **HTTP Client** — Making requests to external services
-29. **Concurrency** — Feature sets are async, statements are sync
-30. **Context-Aware Responses** — Human, machine, and developer output formatting
-31. **Type System** — Primitives, collections, and OpenAPI schemas
+27. **Control Flow** — Guards, match expressions, conditional execution
+28. **Data Pipelines** — Map, Filter, Reduce for collection processing
+29. **Repositories** — Persistent in-memory storage and observers
+30. **System Commands** — Shell execution with the Exec action
+31. **HTTP Client** — Making requests to external services
+32. **Concurrency** — Feature sets are async, statements are sync
+33. **Context-Aware Responses** — Human, machine, and developer output formatting
+34. **Type System** — Primitives, collections, and OpenAPI schemas
+35. **Date and Time** — Temporal operations, comparisons, and formatting
 
 ## Appendices
 - A: Action Reference (all 50 built-in actions)


### PR DESCRIPTION
## Summary

Reindex all book chapters to use sequential numbering from 1-35, removing letter suffixes (6A, 16B, 17B).

## Changes

### File Renaming (29 chapters)
- Chapter 06A → Chapter 07 (Export Actions)
- Chapters 07-16 → Chapters 08-17 (shift +1)
- Chapter 16B → Chapter 18 (Format-Aware I/O)
- Chapter 17 → Chapter 19 (Custom Actions)
- Chapter 17B → Chapter 20 (Custom Services)
- Chapters 18-32 → Chapters 21-35 (shift +3)

### Content Updates
- Updated all chapter titles (e.g., "Chapter 6A" → "Chapter 7")
- Updated all section numbers (e.g., "## 6A.1" → "## 7.1")
- Updated 30+ "Next:" footer links throughout chapters
- Fixed cross-references in Chapter 19 (now references Chapters 20 and 21)
- Added "Next:" link to Chapter 35 → Appendix A
- Fixed Chapter 34 to link to Chapter 35 before Appendix A

### Documentation
- Updated STRUCTURE.md with sequential numbering 1-35
- Added missing Chapter 35 (Date and Time) to STRUCTURE.md

### Build
- Regenerated PDF and HTML with all 35 chapters
- Build successfully includes all sequentially numbered chapters

## Result

✅ All 35 chapters now numbered sequentially: Chapter01 → Chapter35  
✅ No letter suffixes (A, B) in chapter numbering  
✅ All internal references and links updated  
✅ STRUCTURE.md reflects new organization  
✅ PDF/HTML regenerated successfully