### PR TITLE
fix: add missing arrowheads to Decision Guide diagram in Book Chapter 7.5

### DIFF
--- a/Book/TheLanguageGuide/Chapter07-ExportActions.md
+++ b/Book/TheLanguageGuide/Chapter07-ExportActions.md
@@ -294,8 +294,11 @@ Choosing between Store, Emit, and Publish becomes straightforward when you ask t
 
   <!-- Three branches -->
   <line x1="175" y1="45" x2="80" y2="80" stroke="#6b7280" stroke-width="1.5"/>
+  <polygon points="80,80 88,74 84,82" fill="#6b7280"/>
   <line x1="225" y1="45" x2="225" y2="80" stroke="#6b7280" stroke-width="1.5"/>
+  <polygon points="225,80 220,72 230,72" fill="#6b7280"/>
   <line x1="275" y1="45" x2="370" y2="80" stroke="#6b7280" stroke-width="1.5"/>
+  <polygon points="370,80 362,74 366,82" fill="#6b7280"/>
 
   <!-- Store branch -->
   <rect x="20" y="80" width="120" height="45" rx="5" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>


### PR DESCRIPTION
## Summary
- Added missing arrowhead polygons for the three branches in the "Decision Guide" diagram (Chapter 7.5)
- The diagram was missing visual indicators showing flow direction from the top question box
- Now clearly shows the decision flow with proper arrows pointing to each option

## Changes
- Book/TheLanguageGuide/Chapter07-ExportActions.md:297 - Added left diagonal arrow (Store path)
- Book/TheLanguageGuide/Chapter07-ExportActions.md:299 - Added center vertical arrow (Emit path)  
- Book/TheLanguageGuide/Chapter07-ExportActions.md:301 - Added right diagonal arrow (Publish path)

## Test plan
- [x] Verified SVG renders correctly with all three arrowheads visible
- [x] Arrows properly indicate flow from "What do you need?" to decision boxes
- [x] Arrow directions match the diagonal/vertical line paths