### PR TITLE
fix: correct diagonal arrow coordinates in Repository Observers diagram (9.10)

### DIFF
--- a/Book/TheLanguageGuide/Chapter11-EventBus.md
+++ b/Book/TheLanguageGuide/Chapter11-EventBus.md
@@ -151,9 +151,9 @@ Repository observers are a specialized form of event handlers that react to chan
 
   <!-- Fan-out to observers -->
   <line x1="60" y1="100" x2="40" y2="130" stroke="#a855f7" stroke-width="2"/>
-  <polygon points="40,130 48,125 44,133" fill="#a855f7"/>
+  <polygon points="40,130 46,122 34,122" fill="#a855f7"/>
   <line x1="120" y1="100" x2="140" y2="130" stroke="#a855f7" stroke-width="2"/>
-  <polygon points="140,130 132,125 136,133" fill="#a855f7"/>
+  <polygon points="140,130 134,122 146,122" fill="#a855f7"/>
 
   <!-- Observer 1 -->
   <rect x="5" y="135" width="70" height="35" rx="4" fill="#f3e8ff" stroke="#a855f7" stroke-width="2"/>


### PR DESCRIPTION
## Summary
- Fixed broken arrowhead polygons in the "Repository Observers" diagram (Section 9.10)
- The left and right diagonal arrows had incorrect polygon coordinates creating malformed arrowheads
- Updated to proper downward-pointing triangles for both observer paths

## Changes
- Book/TheLanguageGuide/Chapter11-EventBus.md:154 - Fixed left diagonal arrow (Audit Observer)
- Book/TheLanguageGuide/Chapter11-EventBus.md:156 - Fixed right diagonal arrow (Sync Observer)

## Test plan
- [x] Verified SVG renders correctly with proper arrowheads
- [x] Arrows now display as proper downward-pointing triangles
- [x] Consistent with the fixes applied to Chapter 7.1 diagonal arrows