### PR TITLE
fix: improve SVG arrowhead marker in System Objects diagram (18B.1)

### DIFF
--- a/Book/TheLanguageGuide/Chapter18B-SystemObjects.md
+++ b/Book/TheLanguageGuide/Chapter18B-SystemObjects.md
@@ -90,8 +90,8 @@ The following diagram illustrates how data flows between your ARO feature sets a
 
   <!-- Arrows: Sources → Feature Set -->
   <defs>
-    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#2c3e50"/>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" viewBox="0 0 10 6">
+      <polygon points="0,0 10,3 0,6" fill="#2c3e50"/>
     </marker>
   </defs>
 


### PR DESCRIPTION
## Summary
- Enhanced the arrowhead marker definition in the "Source/Sink Flow" diagram (Section 18B.1)
- Improved marker positioning and rendering consistency for all arrows in the diagram
- This marker is reused across all directional flows (REQUEST, EXPORT, and Bidirectional)

## Changes
- Book/TheLanguageGuide/Chapter18B-SystemObjects.md:93 - Added explicit `viewBox="0 0 10 6"` for better coordinate control
- Book/TheLanguageGuide/Chapter18B-SystemObjects.md:93 - Adjusted `refX` from 9 to 10 for precise tip positioning
- Book/TheLanguageGuide/Chapter18B-SystemObjects.md:94 - Cleaned up polygon points formatting

## Test plan
- [x] Verified SVG marker renders correctly on all arrow paths
- [x] Arrowheads now position precisely at path endpoints
- [x] Consistent appearance across all directional arrows in the diagram