### PR TITLE
fix: add missing arrowheads to branch lines in Accept Action diagram (25.4)

### DIFF
--- a/Book/TheLanguageGuide/Chapter25-StateMachines.md
+++ b/Book/TheLanguageGuide/Chapter25-StateMachines.md
@@ -91,10 +91,12 @@ This creates a clear contract: orders have a status field that must be one of th
 
   <!-- Yes branch -->
   <line x1="90" y1="115" x2="50" y2="130" stroke="#22c55e" stroke-width="1.5"/>
+  <polygon points="50,130 56,124 52,132" fill="#22c55e"/>
   <text x="55" y="125" font-family="sans-serif" font-size="7" fill="#22c55e">match</text>
 
   <!-- No branch -->
   <line x1="90" y1="115" x2="130" y2="130" stroke="#ef4444" stroke-width="1.5"/>
+  <polygon points="130,130 124,124 128,132" fill="#ef4444"/>
   <text x="120" y="125" font-family="sans-serif" font-size="7" fill="#ef4444">no match</text>
 
   <!-- Success: Update -->


### PR DESCRIPTION
## Summary
- Added missing arrowhead polygons to validation branch lines in the "Accept Action Flow" diagram (Section 25.4)
- The diagram was missing visual indicators for the flow direction from the validation decision point
- Now clearly shows the match/no-match paths with proper directional arrows

## Changes
- Book/TheLanguageGuide/Chapter25-StateMachines.md:94 - Added arrowhead for "Yes branch" (match path)
- Book/TheLanguageGuide/Chapter25-StateMachines.md:99 - Added arrowhead for "No branch" (no match path)

## Test plan
- [x] Verified SVG renders correctly with both arrowheads visible
- [x] Arrows clearly indicate flow from validation to success/error states
- [x] Visual consistency with other arrows in the diagram