### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cards.yml
+++ b/.github/workflows/cards.yml
@@ -102,6 +102,8 @@ jobs:
   post:
     name: Post Card to Mastodon
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Only run on schedule or manual trigger, not on code changes
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/KrisSimon/aro/security/code-scanning/20](https://github.com/KrisSimon/aro/security/code-scanning/20)

To fix the problem, explicitly define minimal GITHUB_TOKEN permissions for the `post` job instead of relying on repository defaults. The job needs to check out the repository, which requires `contents: read`. It does not push commits, create releases, work with packages, or modify issues/PRs, so no additional write scopes are necessary.

The best fix while preserving existing functionality is:

- Under `jobs.post` (around line 103), add a `permissions` block alongside `runs-on` and `if`.
- Set `contents: read` as the only permission, which is sufficient for `actions/checkout@v6` to clone the repo.
- Leave the existing `build` job’s permissions unchanged, since it already has an appropriate `contents: read` / `packages: write` configuration.

Concretely, in `.github/workflows/cards.yml`, modify the `post` job section by inserting:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and the `if:` condition.

No new methods, imports, or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
