### PR TITLE
Fix cards pipeline: Add missing generate step

### DIFF
--- a/.github/workflows/cards.yml
+++ b/.github/workflows/cards.yml
@@ -120,6 +120,11 @@ jobs:
           cd cards
           npm install
 
+      - name: Generate cards
+        run: |
+          cd cards
+          node generate.js
+
       - name: Post card to Mastodon
         env:
           MASTODON_INSTANCE: ${{ secrets.MASTODON_INSTANCE }}


### PR DESCRIPTION
## Summary
- Add the 'Generate cards' step to the post job in the cards workflow
- This step was missing, causing all scheduled runs to fail since Jan 5

## Problem
The scheduled 'post' job was trying to post cards to Mastodon without first generating the card images. The `post-to-mastodon.js` script reads from the `output/` directory, which only gets created by `generate.js`.

**Failed runs:**
- Jan 5: failure
- Jan 6: failure
- Jan 7: failure
- Jan 8: failure

## Fix
Add the generate step before posting:
```yaml
- name: Generate cards
  run: |
    cd cards
    node generate.js
```

## Test plan
- [x] Verify PR triggers the workflow (path filter: `cards/**`)
- [ ] Manually trigger workflow to confirm cards post successfully