### PR TITLE
Add when clause support to native compilation (ARO-0004)

### DIFF
--- a/Sources/AROCompiler/LLVMCodeGenerator.swift
+++ b/Sources/AROCompiler/LLVMCodeGenerator.swift
@@ -352,6 +352,14 @@ public final class LLVMCodeGenerator {
             if let withClause = aroStatement.withClause {
                 collectStringsFromExpression(withClause)
             }
+
+            // ARO-0004: Collect when clause strings (for guarded statements)
+            if let whenCondition = aroStatement.whenCondition {
+                collectStringsFromExpression(whenCondition)
+                // Also register the JSON for runtime evaluation
+                let whenJSON = expressionToEvalJSON(whenCondition)
+                registerString(whenJSON)
+            }
         } else if let publishStatement = statement as? PublishStatement {
             registerString(publishStatement.externalName)
             registerString(publishStatement.internalVariable)
@@ -679,6 +687,18 @@ public final class LLVMCodeGenerator {
 
         emit("  ; <\(statement.action.verb)> the <\(statement.result.base)> ...")
 
+        // ARO-0004: Handle when clause - skip statement if condition is false
+        if let whenCondition = statement.whenCondition {
+            let whenJSON = expressionToEvalJSON(whenCondition)
+            let whenStr = stringConstants[whenJSON]!
+            emit("  ; Evaluate when guard: \(whenCondition)")
+            emit("  %\(prefix)_when_result = call i32 @aro_evaluate_when_guard(ptr \(currentContext), ptr \(whenStr))")
+            emit("  %\(prefix)_when_pass = icmp ne i32 %\(prefix)_when_result, 0")
+            emit("  br i1 %\(prefix)_when_pass, label %\(prefix)_body, label %\(prefix)_skip")
+            emit("")
+            emit("\(prefix)_body:")
+        }
+
         // If there's a literal value, bind it first
         if let literalValue = statement.literalValue {
             try emitLiteralBinding(literalValue, prefix: prefix)
@@ -780,6 +800,13 @@ public final class LLVMCodeGenerator {
 
         // Store result
         emit("  store ptr %\(prefix)_action_result, ptr %__result")
+
+        // ARO-0004: Add skip label if when clause was present
+        if statement.whenCondition != nil {
+            emit("  br label %\(prefix)_skip")
+            emit("")
+            emit("\(prefix)_skip:")
+        }
         emit("")
     }
 

--- a/Sources/ARORuntime/Bridge/RuntimeBridge.swift
+++ b/Sources/ARORuntime/Bridge/RuntimeBridge.swift
@@ -875,25 +875,29 @@ private func evaluateBinaryOp(op: String, left: any Sendable, right: any Sendabl
         if let l = asDouble(left), let r = asDouble(right) {
             return l < r
         }
-        return false
+        // Fallback to string comparison (works for ISO 8601 dates)
+        return asString(left) < asString(right)
 
     case ">":
         if let l = asDouble(left), let r = asDouble(right) {
             return l > r
         }
-        return false
+        // Fallback to string comparison (works for ISO 8601 dates)
+        return asString(left) > asString(right)
 
     case "<=":
         if let l = asDouble(left), let r = asDouble(right) {
             return l <= r
         }
-        return false
+        // Fallback to string comparison (works for ISO 8601 dates)
+        return asString(left) <= asString(right)
 
     case ">=":
         if let l = asDouble(left), let r = asDouble(right) {
             return l >= r
         }
-        return false
+        // Fallback to string comparison (works for ISO 8601 dates)
+        return asString(left) >= asString(right)
 
     // Logical
     case "and":


### PR DESCRIPTION
## Summary

Native compiled binaries now correctly evaluate `when` clause conditions and skip statements when the condition is false.

Previously, native binaries would execute all statements regardless of their `when` guard conditions, causing incorrect output. This fix adds proper conditional branching in the LLVM code generator.

## Changes

### LLVMCodeGenerator.swift
- Collect when clause expression strings during string constant collection phase
- Generate conditional branching using `aro_evaluate_when_guard` runtime function
- Skip statement execution when guard evaluates to false

### RuntimeBridge.swift
- Fix comparison operators (`<`, `>`, `<=`, `>=`) to fall back to string comparison when numeric comparison fails
- This enables date comparisons since ISO 8601 date strings are lexicographically sortable

## Test Plan

- [x] Verified interpreter produces expected output for DateTimeDemo
- [x] Built native binary with `aro build Examples/DateTimeDemo`
- [x] Confirmed binary output now matches interpreter:

**Before:**
```
Date comparisons:
  Is yesterday before now?
  Is next week after now?
  Is meeting in the past y?
  Is meeting in the past n?   ← INCORRECT (should not appear)
  Is meeting in 2025?
```

**After:**
```
Date comparisons:
  Is yesterday before now?
  Is next week after now?
  Is meeting in the past y?
  Is meeting in 2025?
```

- [x] All 752 tests pass

Fixes #156