### PR TITLE
Fix when clause evaluation and path parameter matching in native binaries

### DIFF
--- a/Sources/ARORuntime/Bridge/RuntimeBridge.swift
+++ b/Sources/ARORuntime/Bridge/RuntimeBridge.swift
@@ -872,6 +872,10 @@ private func evaluateBinaryOp(op: String, left: any Sendable, right: any Sendabl
         return asString(left) != asString(right)
 
     case "<":
+        // Try date comparison first (ARO-0041)
+        if let leftDate = parseARODate(left), let rightDate = parseARODate(right) {
+            return leftDate.date < rightDate.date
+        }
         if let l = asDouble(left), let r = asDouble(right) {
             return l < r
         }
@@ -879,6 +883,10 @@ private func evaluateBinaryOp(op: String, left: any Sendable, right: any Sendabl
         return asString(left) < asString(right)
 
     case ">":
+        // Try date comparison first (ARO-0041)
+        if let leftDate = parseARODate(left), let rightDate = parseARODate(right) {
+            return leftDate.date > rightDate.date
+        }
         if let l = asDouble(left), let r = asDouble(right) {
             return l > r
         }
@@ -886,6 +894,10 @@ private func evaluateBinaryOp(op: String, left: any Sendable, right: any Sendabl
         return asString(left) > asString(right)
 
     case "<=":
+        // Try date comparison first (ARO-0041)
+        if let leftDate = parseARODate(left), let rightDate = parseARODate(right) {
+            return leftDate.date <= rightDate.date
+        }
         if let l = asDouble(left), let r = asDouble(right) {
             return l <= r
         }
@@ -893,6 +905,10 @@ private func evaluateBinaryOp(op: String, left: any Sendable, right: any Sendabl
         return asString(left) <= asString(right)
 
     case ">=":
+        // Try date comparison first (ARO-0041)
+        if let leftDate = parseARODate(left), let rightDate = parseARODate(right) {
+            return leftDate.date >= rightDate.date
+        }
         if let l = asDouble(left), let r = asDouble(right) {
             return l >= r
         }
@@ -945,6 +961,18 @@ private func asBool(_ value: any Sendable) -> Bool {
     case let s as String: return s.lowercased() == "true"
     default: return false
     }
+}
+
+/// Parse a value as an ARODate (ARO-0041)
+/// Handles ARODate objects and ISO8601 date strings
+private func parseARODate(_ value: any Sendable) -> ARODate? {
+    if let date = value as? ARODate {
+        return date
+    }
+    if let str = value as? String {
+        return try? ARODate.parse(str)
+    }
+    return nil
 }
 
 /// Resolve a variable from the context


### PR DESCRIPTION
## Summary
- Fix #156: When clause conditions are now correctly evaluated in native compiled binaries
- Fix #155: OpenAPI path parameters (like `/users/{id}`) now match correctly in native binaries

## Changes

### Issue #156: When clause conditions ignored
**Root cause:** The LLVM code generator declared `aro_evaluate_when_guard()` but never called it when generating statement code.

**Fix:**
- Add when guard evaluation to `generateAROStatement()` in LLVMCodeGenerator.swift
- Generate conditional branching that skips statements when guard evaluates to false
- Serialize when condition expressions to JSON for runtime evaluation
- Add date comparison support to RuntimeBridge's `evaluateBinaryOp()` (required for comparing dates)

### Issue #155: RepositoryObserver generic responses
**Root cause:** The native HTTP server did exact path matching (`route.path == actual`) which failed for OpenAPI path parameters like `/users/{id}`.

**Fix:**
- Add `matchPath()` function that handles OpenAPI-style path parameters
- Pattern `/users/{id}` now correctly matches `/users/123`
- Extract path parameters and bind to context as `pathParameters` variable
- Feature sets can use `<Extract> the <id> from the <pathParameters: id>` 

## Test plan
- [x] All 752 unit tests pass
- [x] DateTimeDemo: when clauses work correctly (only conditional lines appear)
- [x] RepositoryObserver: all endpoints respond with actual feature set output
- [x] SystemMonitor: HTTP server binary still works

**DateTimeDemo output comparison:**

| Output Line | Before (Binary) | After (Binary) | Interpreter |
|-------------|-----------------|----------------|-------------|
| Is yesterday before now? | ❌ missing | ✅ shows | ✅ shows |
| Is next week after now? | ❌ missing | ✅ shows | ✅ shows |
| Is meeting in the past y? | ❌ missing | ✅ shows | ✅ shows |
| Is meeting in the past n? | ❌ wrongly shown | ✅ correctly skipped | ✅ correctly skipped |
| Is meeting in 2025? | ❌ missing | ✅ shows | ✅ shows |

**RepositoryObserver path parameter test:**
```bash
# Before fix
GET /users/123 → {"error":"Not Found"}

# After fix  
GET /users/123 → {"data":[]}  # Actual feature set response
```

Closes #156
Closes #155