### PR TITLE
Add TypedValue wrapper for early type assignment

### DIFF
--- a/Sources/ARORuntime/Actions/ActionError.swift
+++ b/Sources/ARORuntime/Actions/ActionError.swift
@@ -131,7 +131,7 @@ public enum ActionError: Error, Sendable {
     case undefinedRepository(String)
 
     /// Type mismatch during execution
-    case typeMismatch(expected: String, actual: String)
+    case typeMismatch(expected: String, actual: String, variable: String? = nil)
 
     /// Explicit throw from user code
     case thrown(type: String, reason: String, context: String)
@@ -185,7 +185,10 @@ extension ActionError: CustomStringConvertible {
             return "Service not registered: '\(name)'"
         case .undefinedRepository(let name):
             return "Repository not found: '\(name)'"
-        case .typeMismatch(let expected, let actual):
+        case .typeMismatch(let expected, let actual, let variable):
+            if let varName = variable {
+                return "Type mismatch for '\(varName)': expected '\(expected)', got '\(actual)'"
+            }
             return "Type mismatch: expected '\(expected)', got '\(actual)'"
         case .thrown(let type, let reason, let context):
             return "\(type) in \(context): \(reason)"

--- a/Sources/ARORuntime/Actions/ActionProtocol.swift
+++ b/Sources/ARORuntime/Actions/ActionProtocol.swift
@@ -95,4 +95,136 @@ public extension ActionImplementation {
     static func handles(verb: String) -> Bool {
         verbs.contains(verb.lowercased())
     }
+
+    // MARK: - Type-Safe Value Extraction
+
+    /// Resolve a typed value from context
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The TypedValue if found, nil otherwise
+    func resolveTyped(_ name: String, from context: ExecutionContext) -> TypedValue? {
+        context.resolveTyped(name)
+    }
+
+    /// Require a string value, throwing on missing or type mismatch
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The string value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireString(_ name: String, from context: ExecutionContext) throws -> String {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let str = typed.asString() else {
+            throw ActionError.typeMismatch(
+                expected: "String",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return str
+    }
+
+    /// Require an integer value, throwing on missing or type mismatch
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The integer value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireInt(_ name: String, from context: ExecutionContext) throws -> Int {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let i = typed.asInt() else {
+            throw ActionError.typeMismatch(
+                expected: "Integer",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return i
+    }
+
+    /// Require a double/float value, throwing on missing or type mismatch
+    /// Also accepts Int and converts to Double
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The double value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireDouble(_ name: String, from context: ExecutionContext) throws -> Double {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let d = typed.asDouble() else {
+            throw ActionError.typeMismatch(
+                expected: "Float",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return d
+    }
+
+    /// Require a boolean value, throwing on missing or type mismatch
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The boolean value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireBool(_ name: String, from context: ExecutionContext) throws -> Bool {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let b = typed.asBool() else {
+            throw ActionError.typeMismatch(
+                expected: "Boolean",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return b
+    }
+
+    /// Require a list/array value, throwing on missing or type mismatch
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The array value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireList(_ name: String, from context: ExecutionContext) throws -> [any Sendable] {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let arr = typed.asList() else {
+            throw ActionError.typeMismatch(
+                expected: "List",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return arr
+    }
+
+    /// Require a dictionary/map value, throwing on missing or type mismatch
+    /// - Parameters:
+    ///   - name: Variable name to resolve
+    ///   - context: The execution context
+    /// - Returns: The dictionary value
+    /// - Throws: ActionError.undefinedVariable or ActionError.typeMismatch
+    func requireDict(_ name: String, from context: ExecutionContext) throws -> [String: any Sendable] {
+        guard let typed = context.resolveTyped(name) else {
+            throw ActionError.undefinedVariable(name)
+        }
+        guard let dict = typed.asDict() else {
+            throw ActionError.typeMismatch(
+                expected: "Map",
+                actual: typed.type.description,
+                variable: name
+            )
+        }
+        return dict
+    }
 }

--- a/Sources/ARORuntime/Core/TypedValue.swift
+++ b/Sources/ARORuntime/Core/TypedValue.swift
@@ -1,0 +1,212 @@
+// ============================================================
+// TypedValue.swift
+// ARO Runtime - Typed Value Wrapper
+// ============================================================
+
+import Foundation
+import AROParser
+
+/// A value paired with its type information
+///
+/// TypedValue wraps runtime values with their DataType, enabling:
+/// - Type preservation from parse time through runtime
+/// - Centralized type checking instead of scattered `is`/`as?` checks
+/// - Better error messages with expected vs actual type info
+public struct TypedValue: Sendable, CustomStringConvertible {
+    // MARK: - Properties
+
+    /// The underlying value
+    public let value: any Sendable
+
+    /// The type of the value
+    public let type: DataType
+
+    // MARK: - Initialization
+
+    /// Create a typed value
+    /// - Parameters:
+    ///   - value: The underlying value
+    ///   - type: The type (defaults to .unknown for gradual typing)
+    public init(_ value: any Sendable, type: DataType = .unknown) {
+        self.value = value
+        self.type = type
+    }
+
+    // MARK: - Convenience Constructors
+
+    /// Create a typed string value
+    public static func string(_ s: String) -> TypedValue {
+        TypedValue(s, type: .string)
+    }
+
+    /// Create a typed integer value
+    public static func integer(_ i: Int) -> TypedValue {
+        TypedValue(i, type: .integer)
+    }
+
+    /// Create a typed float value
+    public static func float(_ d: Double) -> TypedValue {
+        TypedValue(d, type: .float)
+    }
+
+    /// Create a typed boolean value
+    public static func boolean(_ b: Bool) -> TypedValue {
+        TypedValue(b, type: .boolean)
+    }
+
+    /// Create a typed list value
+    /// - Parameters:
+    ///   - arr: The array value
+    ///   - elementType: The element type (defaults to .unknown)
+    public static func list(_ arr: [any Sendable], elementType: DataType = .unknown) -> TypedValue {
+        TypedValue(arr, type: .list(elementType))
+    }
+
+    /// Create a typed map value
+    /// - Parameters:
+    ///   - dict: The dictionary value
+    ///   - keyType: The key type (defaults to .string)
+    ///   - valueType: The value type (defaults to .unknown)
+    public static func map(
+        _ dict: [String: any Sendable],
+        keyType: DataType = .string,
+        valueType: DataType = .unknown
+    ) -> TypedValue {
+        TypedValue(dict, type: .map(key: keyType, value: valueType))
+    }
+
+    /// Create a typed value with a schema type
+    /// - Parameters:
+    ///   - value: The value (typically a dictionary matching the schema)
+    ///   - schemaName: The OpenAPI schema name
+    public static func schema(_ value: any Sendable, schemaName: String) -> TypedValue {
+        TypedValue(value, type: .schema(schemaName))
+    }
+
+    // MARK: - Type-Safe Extraction
+
+    /// Extract as String if the value is a string
+    public func asString() -> String? {
+        value as? String
+    }
+
+    /// Extract as Int if the value is an integer
+    public func asInt() -> Int? {
+        value as? Int
+    }
+
+    /// Extract as Double if the value is a float/double
+    /// Also handles Int -> Double conversion
+    public func asDouble() -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        return nil
+    }
+
+    /// Extract as Bool if the value is a boolean
+    public func asBool() -> Bool? {
+        value as? Bool
+    }
+
+    /// Extract as array if the value is a list
+    public func asList() -> [any Sendable]? {
+        value as? [any Sendable]
+    }
+
+    /// Extract as dictionary if the value is a map
+    public func asDict() -> [String: any Sendable]? {
+        value as? [String: any Sendable]
+    }
+
+    // MARK: - Type Checking
+
+    /// Check if this value is of the expected type
+    public func isType(_ expected: DataType) -> Bool {
+        type.isAssignableTo(expected)
+    }
+
+    /// Check if this value is a primitive type
+    public var isPrimitive: Bool {
+        type.isPrimitive
+    }
+
+    /// Check if this value is a collection type
+    public var isCollection: Bool {
+        type.isCollection
+    }
+
+    /// Check if this value has unknown type
+    public var isUnknown: Bool {
+        type == .unknown
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        "\(value) : \(type)"
+    }
+}
+
+// MARK: - Type Inference
+
+extension TypedValue {
+    /// Create a TypedValue by inferring the type from the value
+    /// - Parameter value: The value to wrap
+    /// - Returns: A TypedValue with inferred type
+    public static func infer(_ value: any Sendable) -> TypedValue {
+        TypedValue(value, type: inferType(value))
+    }
+
+    /// Infer the DataType from a runtime value
+    /// - Parameter value: The value to inspect
+    /// - Returns: The inferred DataType
+    public static func inferType(_ value: any Sendable) -> DataType {
+        switch value {
+        case is String:
+            return .string
+        case is Int:
+            return .integer
+        case is Double:
+            return .float
+        case is Bool:
+            return .boolean
+        case let arr as [any Sendable]:
+            // Infer element type from first element
+            if let first = arr.first {
+                return .list(inferType(first))
+            }
+            return .list(.unknown)
+        case is [String: any Sendable]:
+            return .map(key: .string, value: .unknown)
+        case let typed as TypedValue:
+            // Already typed, preserve it
+            return typed.type
+        default:
+            return .unknown
+        }
+    }
+}
+
+// MARK: - Equatable (for testing)
+
+extension TypedValue: Equatable {
+    public static func == (lhs: TypedValue, rhs: TypedValue) -> Bool {
+        // Types must match
+        guard lhs.type == rhs.type else { return false }
+
+        // Compare values based on type
+        switch lhs.type {
+        case .string:
+            return lhs.asString() == rhs.asString()
+        case .integer:
+            return lhs.asInt() == rhs.asInt()
+        case .float:
+            return lhs.asDouble() == rhs.asDouble()
+        case .boolean:
+            return lhs.asBool() == rhs.asBool()
+        default:
+            // For complex types, use string representation
+            return String(describing: lhs.value) == String(describing: rhs.value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `TypedValue` struct that pairs runtime values with their `DataType`
- Enables type preservation from parse time through runtime
- Centralizes type handling, reducing scattered `is`/`as?` checks across actions

## Changes

| File | Changes |
|------|---------|
| `TypedValue.swift` | **NEW** - Core struct with type inference and convenience constructors |
| `RuntimeContext.swift` | Storage changed to `[String: TypedValue]`, added typed methods |
| `ExecutionContext.swift` | Protocol extended with `resolveTyped()`, `bindTyped()`, `typeOf()` |
| `ActionProtocol.swift` | Helper methods: `requireString()`, `requireInt()`, etc. |
| `ActionError.swift` | Enhanced `typeMismatch` to include variable name |

## Benefits

1. **Type preservation**: Types flow from parser through runtime without rediscovery
2. **Centralized checking**: Actions can use `requireString()` instead of scattered `as?` casts
3. **Better errors**: Type mismatches include expected vs actual type and variable name
4. **Future-ready**: Foundation for LLVM type-based optimizations

## Backward Compatibility

Fully backward compatible - existing `bind()`/`resolve()` calls auto-wrap values with inferred types via `TypedValue.infer()`.

## Test plan

- [x] All 817 unit tests pass
- [x] Interpreter works (tested with Computations example)
- [x] LLVM compiler works (tested with HelloWorld binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)