### PR TITLE
Re-enable Windows build and integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -451,10 +451,9 @@ jobs:
           retention-days: 30
 
   # ===========================================================================
-  # Windows Build & Test (temporarily disabled)
+  # Windows Build & Test
   # ===========================================================================
   windows:
-    if: false
     needs: test
     name: Windows
     permissions:
@@ -854,10 +853,9 @@ jobs:
           retention-days: 7
 
   # ===========================================================================
-  # Integration Tests - Windows (temporarily disabled)
+  # Integration Tests - Windows
   # ===========================================================================
   integration-tests-windows:
-    if: false
     needs: [windows]
     name: Integration Tests - Windows
     runs-on: windows-latest
@@ -1066,7 +1064,7 @@ jobs:
   # ===========================================================================
   release:
     name: Create Release
-    needs: [linux, macos, integration-tests-linux, integration-tests-macos, documentation]
+    needs: [linux, macos, windows, integration-tests-linux, integration-tests-macos, integration-tests-windows, documentation]
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     permissions:


### PR DESCRIPTION
## Summary

This PR re-enables the Windows build and integration test jobs in CI, which were temporarily disabled on `main` because they kept failing the pipeline.

## Why this is hard

Getting ARO to build and pass tests on Windows has been a persistent challenge due to several compounding issues:

- **Swift on Windows is still maturing.** The Swift toolchain on Windows has platform-specific gaps — missing modules, different linking behavior, and inconsistent Foundation support compared to macOS/Linux. Errors that don't exist on other platforms surface here.
- **Signal handling differs fundamentally.** ARO's Keepalive mechanism relies on POSIX signals (SIGINT/SIGTERM) for graceful shutdown. Windows doesn't have POSIX signals in the same way, requiring `SetConsoleCtrlHandler` or similar alternatives, which means platform-specific codepaths.
- **Plugin system depends on dynamic loading.** The plugin architecture uses `dlopen`/`dlsym` on Unix but needs `LoadLibrary`/`GetProcAddress` on Windows. The conditional compilation paths exist but are undertested.
- **Integration tests need platform-specific skips.** Several examples (SQLiteExample, ZipService, EchoSocket, HTTP tests) depend on libraries or system features that aren't available or behave differently on Windows CI runners. The test harness supports `skip-on-windows` hints, but getting the right set of skips without masking real failures is trial and error.
- **CI runner environment is fragile.** The Windows GitHub Actions runner needs Swift installed via a specific setup action, and LLVM/clang toolchain availability for `aro build` (native compilation) is not guaranteed. Path handling (`\` vs `/`), temp directory locations, and shell differences (PowerShell vs cmd) add friction to every CI step.

## Help wanted

If anyone has experience with Swift on Windows or wants to help debug the CI failures, contributions are very welcome. The pipeline will run on this branch so failures are visible without blocking `main`.

Key areas where help would be useful:
- Fixing Windows-specific build errors in the Swift compilation
- Getting the native compilation pipeline (`aro build`) working with LLVM on Windows
- Validating which integration tests can realistically pass on Windows and updating `test.hint` files accordingly
- Improving signal handling for graceful shutdown on Windows