### PR TITLE
docs(website): sync proposals and actions with 0.9.x

### DIFF
--- a/Website/src/docs.html
+++ b/Website/src/docs.html
@@ -510,7 +510,7 @@
                     <div class="doc-card-icon">&#x1F4C3;</div>
                     <h3>Language Proposals</h3>
                     <p>
-                        59 evolution proposals documenting every aspect of the
+                        60+ evolution proposals documenting every aspect of the
                         ARO language design.
                     </p>
                     <span class="doc-card-link">Browse proposals →</span>

--- a/Website/src/docs/actions.html
+++ b/Website/src/docs/actions.html
@@ -389,6 +389,36 @@ if &lt;validation&gt; is failed then {
         <pre><code><span class="code-keyword">Assert</span> the &lt;value&gt; equals &lt;expected&gt;.
 <span class="code-keyword">Assert</span> the &lt;list&gt; contains &lt;item&gt;.</code></pre>
 
+        <h2>Git Actions</h2>
+        <p>Native version control via libgit2 (ARO-0080). The <code>&lt;git&gt;</code> system object defaults to the current working directory; use <code>&lt;git: "/path"&gt;</code> for an explicit repository.</p>
+
+        <h3>Status, Log, Branch</h3>
+        <p>Inspect the working tree using Retrieve:</p>
+        <pre><code><span class="code-keyword">Retrieve</span> the <span class="code-result">&lt;status&gt;</span> from the &lt;git&gt;.
+<span class="code-keyword">Retrieve</span> the <span class="code-result">&lt;log&gt;</span> from the &lt;git&gt;.
+<span class="code-keyword">Retrieve</span> the <span class="code-result">&lt;branch&gt;</span> from the &lt;git&gt;.</code></pre>
+
+        <h3>Stage and Commit</h3>
+        <p>Stage files and create commits:</p>
+        <pre><code><span class="code-keyword">Stage</span> the &lt;files&gt; to the &lt;git&gt; with <span class="code-string">"."</span>.
+<span class="code-keyword">Commit</span> the <span class="code-result">&lt;result&gt;</span> to the &lt;git&gt; with <span class="code-string">"feat: add feature"</span>.</code></pre>
+
+        <h3>Pull and Push</h3>
+        <p>Synchronise with remotes (delegates to the git CLI):</p>
+        <pre><code><span class="code-keyword">Pull</span> the <span class="code-result">&lt;updates&gt;</span> from the &lt;git&gt;.
+<span class="code-keyword">Push</span> the <span class="code-result">&lt;result&gt;</span> to the &lt;git&gt;.</code></pre>
+
+        <h3>Clone, Checkout, Tag</h3>
+        <p>Branching, tagging, and cloning repositories:</p>
+        <pre><code><span class="code-keyword">Clone</span> the <span class="code-result">&lt;repo&gt;</span> from the &lt;git&gt; with {
+    url: <span class="code-string">"https://github.com/user/repo.git"</span>,
+    path: <span class="code-string">"./cloned"</span>
+}.
+<span class="code-keyword">Checkout</span> the <span class="code-result">&lt;branch&gt;</span> from the &lt;git&gt; with <span class="code-string">"feature/new"</span>.
+<span class="code-keyword">Tag</span> the <span class="code-result">&lt;release&gt;</span> for the &lt;git&gt; with <span class="code-string">"v1.0.0"</span>.</code></pre>
+
+        <p>Git actions emit events for reactive workflows: <code>GitCommit</code>, <code>GitPush</code>, <code>GitPull</code>, <code>GitCheckout</code>, <code>GitTag</code>, <code>GitClone</code>.</p>
+
         <h2>Action Patterns</h2>
 
         <h3>Extract-Process-Return</h3>

--- a/Website/src/docs/language-proposals.html
+++ b/Website/src/docs/language-proposals.html
@@ -59,7 +59,7 @@
         <header class="doc-header">
             <h1 class="gradient-text">Language Specifications</h1>
             <p class="lead">
-                The ARO language is documented through 34 comprehensive specifications
+                The ARO language is documented through 60+ comprehensive specifications
                 that cover everything from core syntax to native compilation.
             </p>
         </header>
@@ -73,7 +73,7 @@
         </div>
 
         <h2>Language Specifications</h2>
-        <p>These 34 documents define the complete ARO language.</p>
+        <p>These documents define the complete ARO language.</p>
 
         <table>
             <thead>
@@ -98,7 +98,7 @@
                 <tr>
                     <td>0004</td>
                     <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0004-actions.md" class="proposal-link">Actions</a></td>
-                    <td>Action roles, 48 built-in actions, custom extensions</td>
+                    <td>Action roles, built-in actions, custom extensions</td>
                 </tr>
                 <tr>
                     <td>0005</td>
@@ -129,6 +129,11 @@
                     <td>0010</td>
                     <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0010-advanced-features.md" class="proposal-link">Advanced Features</a></td>
                     <td>Regular expressions, date/time, system exec</td>
+                </tr>
+                <tr>
+                    <td>0011</td>
+                    <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0011-html-xml-parsing.md" class="proposal-link">HTML/XML Parsing</a></td>
+                    <td>Parse action for HTML and XML documents</td>
                 </tr>
                 <tr>
                     <td>0014</td>
@@ -241,6 +246,11 @@
                     <td>WebSocket server support, real-time messaging</td>
                 </tr>
                 <tr>
+                    <td>0049</td>
+                    <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0049-repl.md" class="proposal-link">Interactive REPL</a></td>
+                    <td>Read-eval-print loop, plugin management commands</td>
+                </tr>
+                <tr>
                     <td>0050</td>
                     <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0050-template-engine.md" class="proposal-link">Template Engine</a></td>
                     <td>Mustache-style templates, Render action</td>
@@ -249,6 +259,21 @@
                     <td>0051</td>
                     <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0051-streaming-execution.md" class="proposal-link">Streaming Execution</a></td>
                     <td>Lazy evaluation, Stream Tee, Aggregation Fusion</td>
+                </tr>
+                <tr>
+                    <td>0073</td>
+                    <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0073-store-files.md" class="proposal-link">Store Files</a></td>
+                    <td>File-backed repositories, YAML seed data, permission-based writability</td>
+                </tr>
+                <tr>
+                    <td>0080</td>
+                    <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0080-git-actions.md" class="proposal-link">Git Actions</a></td>
+                    <td>Native Git via libgit2: status, stage, commit, push, pull, clone, checkout, tag</td>
+                </tr>
+                <tr>
+                    <td>0081</td>
+                    <td><a href="https://github.com/arolang/aro/blob/main/Proposals/ARO-0081-user-defined-actions.md" class="proposal-link">User-Defined Actions</a></td>
+                    <td>Define custom actions in ARO source files</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Feature sets with the Action activity become callable application-wide
as Application.<Name>, with a call-site shape identical to plugin actions.
Single-value sugar via 'takes <field>' in the header; object input via
'with { ... }'. Framework variables are forbidden inside action bodies;
events and other actions can be invoked freely.
