### PR TITLE
feat(parser,runtime): user-defined actions (ARO-0081, #224)

### DIFF
--- a/Book/TheLanguageGuide/Chapter06-FeatureSets.md
+++ b/Book/TheLanguageGuide/Chapter06-FeatureSets.md
@@ -52,11 +52,88 @@ Feature sets execute in response to events. The runtime maintains an event bus t
 | Custom Event | `{EventName} Handler` | `UserCreated Handler` |
 | File Event | `File Event Handler` | React to file changes |
 | Socket Event | `Socket Event Handler` | React to socket messages |
+| User-Defined Action | `Action [takes <field>]` | Callable as `Application.<Name>` |
 > **See Chapter 14** for application lifecycle details (startup, shutdown, Keepalive).
 > **See Chapter 13** for event bus mechanics and handler patterns.
+> **See section 6.4** for user-defined actions.
 ---
 
-## 6.4 Handler Guards
+## 6.4 User-Defined Actions
+
+A feature set whose business activity is exactly `Action` becomes a **user-defined action**: a synchronous transformation that other feature sets can invoke directly under the `Application.` handle. The call site looks identical to a plugin action, so the same mental model covers built-ins, plugins, and ARO-defined actions.
+
+```aro
+(DoubleValue: Action takes <number>) {
+    Extract the <n> from the <input: number>.
+    Compute the <doubled> from <n> * 2.
+    Return an <OK: status> with { doubled: <doubled> }.
+}
+
+(Application-Start: Demo) {
+    (* Object form — always works *)
+    Application.DoubleValue the <result> with { number: 5 }.
+    Extract the <ten> from the <result: doubled>.
+
+    (* Sugar form — only when the action declares `takes <field>` *)
+    Application.DoubleValue the <also> from 7.
+    Extract the <fourteen> from the <also: doubled>.
+
+    Return an <OK: status> for the <startup>.
+}
+```
+
+### The takes sugar slot
+
+The optional `takes <field[: Type]>` clause declares a single positional parameter. When set, callers may pass `from <value>` instead of `with { field: <value> }`. The two calls below are equivalent:
+
+```aro
+Application.DoubleValue the <r> from 5.
+Application.DoubleValue the <r> with { number: 5 }.
+```
+
+If an action does not declare `takes`, calling it with `from <value>` is a compile error with a hint pointing at the `with { … }` form.
+
+### What the action sees
+
+Inside an `Action` body, the input is exposed as the synthetic `<input>` conduit, the same shape as `<event: x>` in event handlers and `<request: body>` in HTTP routes:
+
+```aro
+(CreateGreeting: Action) {
+    Extract the <name> from the <input: name>.
+    Extract the <salutation> from the <input: salutation>.
+    Compute the <greeting> from <salutation> ++ ", " ++ <name>.
+    Return an <OK: status> with { greeting: <greeting> }.
+}
+```
+
+User-defined actions are synchronous transformations with no event/request context. The compiler **rejects** references to framework variables — `<request>`, `<response>`, `<event>`, `<pathParameters>`, `<queryParameters>` — inside an Action body. Pass everything you need through `<input>`.
+
+### What the caller sees
+
+The result variable holds the **whole returned record** — `status`, optional `reason`, and every field from the `Return ... with { … }` payload, flattened together:
+
+```aro
+Application.DoubleValue the <r> with { number: 5 }.
+(* <r> is now { status: "OK", doubled: 10 } *)
+Extract the <ten> from the <r: doubled>.
+```
+
+When the body uses `Return an <OK: status> with <variable>` and `<variable>` resolves to a primitive (Int/Double/Bool/String), the value lands under the `value` key — call sites then `Extract … from <r: value>`. Use the object-literal form `with { name: <variable> }` whenever you want a specific field name.
+
+### Composition and validation
+
+Actions can call other actions (built-in, plugin, or user-defined), including themselves. Discovery is automatic — every `Action` feature set in any `.aro` file is registered before `Application-Start` runs. The compiler validates statically:
+
+- duplicate action names are an error;
+- `Application.<Name>` calls referencing a non-existent action are an error with a list of known actions;
+- using `from <value>` against an action without a `takes` clause is an error;
+- referencing framework variables inside an Action body is an error.
+
+> **See `Examples/UserDefinedActions/`** for a runnable demo. **See ARO-0081** in `Proposals/` for the full specification.
+
+---
+
+## 6.5 Handler Guards
 
 Event handler feature sets can declare a `when` guard directly on the header. The `when` keyword appears between the closing parenthesis and the opening brace, followed by a condition expression. The runtime evaluates this condition each time the event is delivered. If the condition is false, the handler is silently skipped—no statements execute and no error is reported.
 
@@ -103,16 +180,16 @@ The guard is evaluated with the same comparison operators available in `Filter` 
 
 ---
 
-## 6.5 Structure and Execution
+## 6.6 Structure and Execution
 
 Within a feature set, statements execute in order from top to bottom. There is no branching, no looping, no early return. Execution begins with the first statement and proceeds through each subsequent statement until reaching the end or encountering an error.
 This linearity might seem limiting, but it actually simplifies reasoning about code. When you look at a feature set, you know exactly what order things happen. There are no hidden control flows, no callbacks that might execute at unexpected times, no conditional branches that might skip important steps. What you see is what executes.
-The `when` clause provides conditional execution without branching. A statement with a when clause executes only if the condition is true; otherwise, the statement is skipped and execution continues with the next statement. This is not a branch—there is no else path, no alternative action. Either the statement happens or it does not. (For filtering an entire handler based on event data, use the declaration-level `when` guard described in section 5.4.)
+The `when` clause provides conditional execution without branching. A statement with a when clause executes only if the condition is true; otherwise, the statement is skipped and execution continues with the next statement. This is not a branch—there is no else path, no alternative action. Either the statement happens or it does not. (For filtering an entire handler based on event data, use the declaration-level `when` guard described in section 6.5.)
 Each statement can bind a result to a name. That binding becomes available to all subsequent statements in the same feature set. If you create a value named `user` in the first statement, you can reference `user` in the second, third, and all following statements. This accumulation of bindings creates the context in which later statements operate.
 Bindings are immutable within a feature set. Once you bind a name to a value, you cannot rebind it to a different value. If you try, the compiler reports an error. This constraint prevents a common class of bugs where a variable changes unexpectedly. It also pushes you toward descriptive names because you cannot reuse generic names like `temp` or `result`.
 ---
 
-## 6.6 Scope and Visibility
+## 6.7 Scope and Visibility
 
 Variables bound within a feature set are visible only within that feature set. A binding in one feature set does not affect bindings in another. Each feature set has its own isolated symbol table that begins empty and accumulates bindings as statements execute.
 This isolation has important implications. If you create a value in one feature set and need to use it in another, you cannot simply reference it by name. The second feature set has no knowledge of what the first feature set bound. This prevents accidental coupling between feature sets that happen to use the same variable names.
@@ -121,7 +198,7 @@ The second option is the Publish action, which makes a binding available to othe
 The execution context provides access to information that is always available. For HTTP handlers, this includes request data: path parameters extracted from the URL, query parameters, headers, and the request body. For event handlers, this includes the event payload containing whatever data was emitted with the event. These context values are not bound to names in advance; you extract them using the Extract action, which binds them to names you choose.
 ---
 
-## 6.7 Naming Conventions
+## 6.8 Naming Conventions
 
 Good naming makes code readable. In ARO, feature set names serve double duty as identifiers and documentation, so choosing appropriate names is particularly important.
 For HTTP handlers, names should match the operation identifiers in your OpenAPI specification exactly. This is not a convention but a requirement—the routing mechanism uses name matching to connect requests to handlers. Operation identifiers typically follow camelCase conventions: `listUsers`, `createOrder`, `getProductById`. Your feature set names should match.
@@ -130,7 +207,7 @@ For lifecycle handlers, use the reserved names exactly as specified. `Applicatio
 For internal feature sets that handle domain logic but are not directly triggered by external events, use names that describe the business operation. `Calculate Shipping`, `Validate Payment`, `Check Inventory`. These feature sets might be triggered by custom events emitted from other feature sets or might be called through other mechanisms.
 ---
 
-## 6.8 File Organization
+## 6.9 File Organization
 
 ARO applications are directories, and the runtime automatically discovers all files with the `.aro` extension in that directory. You do not need import statements or explicit file references. When you create a new file and add feature sets to it, those feature sets become part of the application immediately.
 This automatic discovery encourages organizing feature sets into files by domain or purpose. A typical pattern separates lifecycle concerns from business logic: one file for application start and shutdown, other files for different domains of functionality. A user service might have a main file for lifecycle, a users file for user-related HTTP handlers, an orders file for order-related handlers, and an events file for event handlers.
@@ -138,7 +215,7 @@ The specific organization you choose matters less than consistency. Some teams p
 Because there are no imports, all feature sets are visible throughout the application. An event emitted in one file triggers handlers defined in any file. A variable published in one file is accessible from any feature set with the same business activity, regardless of which file it is defined in. This visibility is powerful but requires discipline. Establish conventions for how feature sets in different files should interact, and document those conventions so team members can follow them.
 ---
 
-## 6.9 The Context Object
+## 6.10 The Context Object
 
 When a feature set executes, it has access to contextual information appropriate to how it was triggered. This information is available through special identifiers that you access using the Extract action.
 HTTP handlers have access to request data. The `pathParameters` object contains values extracted from the URL path based on path templates in the OpenAPI specification. If the path template is `/users/{id}`, the `id` path parameter contains whatever value appeared in that position of the actual URL. The `queryParameters` object contains query string parameters. The `headers` object contains HTTP headers. The `request` object contains the full request, including the body.
@@ -147,7 +224,7 @@ File event handlers have access to file system event details: the path of the fi
 You access context data using the Extract action with qualifiers. The expression `<pathParameters: id>` means "the id property of the pathParameters object." The expression `<event: user.email>` means "the email property of the user property of the event object." Qualifiers chain to allow navigation into nested structures.
 ---
 
-## 6.10 From Here
+## 6.11 From Here
 
 Feature sets are the building blocks of ARO applications. They respond to events, execute statements, and either complete successfully or encounter errors. The runtime orchestrates their execution based on matching patterns between events and feature set headers.
 The next chapter explores how data flows through feature sets and between them. Understanding data flow is essential for building applications that share information appropriately while maintaining the loose coupling that makes event-driven architectures powerful.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,7 @@ Examples/               # 65 examples organized by category (run `ls Examples/` 
 ├── Scoping/            # Publish as, business activity scope, framework vars, pipeline, loop isolation
 ├── Immutability/       # Immutable bindings, new-name pattern, qualifier-as-name
 ├── ErrorHandling/      # Error philosophy demonstration
+├── UserDefinedActions/ # Application.<Name> callable actions (ARO-0081)
 │
 │   # Events & Lifecycle
 ├── EventExample/       # Custom event emission and handling
@@ -609,7 +610,8 @@ Proposals/              # Language specifications
 ├── ARO-0048-websocket.md
 ├── ARO-0051-streaming-execution.md
 ├── ARO-0073-store-files.md
-└── ARO-0080-git-actions.md
+├── ARO-0080-git-actions.md
+└── ARO-0081-user-defined-actions.md
 ```
 
 ## Language Proposals
@@ -655,6 +657,7 @@ The `Proposals/` directory contains language specifications:
 | **0051 Streaming Execution** | Lazy evaluation, Stream Tee, Aggregation Fusion |
 | **0073 Store Files** | File-backed repositories, YAML seed data, permission-based writability |
 | **0080 Git Actions** | Native Git via libgit2: status, stage, commit, push, pull, clone, checkout, tag |
+| **0081 User-Defined Actions** | Feature sets callable as `Application.<Name>` from any other feature set |
 
 ## Concurrency
 

--- a/Examples/UserDefinedActions/main.aro
+++ b/Examples/UserDefinedActions/main.aro
@@ -1,0 +1,55 @@
+(* UserDefinedActions — Demonstrates ARO-0081 user-defined actions
+ *
+ * User-defined actions are feature sets whose business activity is `Action`.
+ * They become callable application-wide as `Application.<Name>`, with the
+ * same call-site syntax as plugin actions. Use them to factor reusable
+ * business logic without writing a plugin or going through the event bus.
+ *)
+
+(* DoubleValue — a one-argument action using the `takes` sugar slot.
+ * Callers can invoke it either positionally with `from <n>`
+ * or with an explicit object: `with { number: <n> }`.
+ *)
+(DoubleValue: Action takes <number>) {
+    Extract the <n> from the <input: number>.
+    Compute the <doubled> from <n> * 2.
+    (* Use the object-literal form so the caller can pull a named field
+     * out of the returned record via `<result: doubled>` *)
+    Return an <OK: status> with { doubled: <doubled> }.
+}
+
+(* SumAndDouble — composes another user-defined action.
+ * Demonstrates: object input form, `Application.` recursion-friendly call,
+ * and pulling a single field out of the returned object.
+ *)
+(SumAndDouble: Action) {
+    Extract the <a> from the <input: a>.
+    Extract the <b> from the <input: b>.
+    Compute the <sum> from <a> + <b>.
+
+    Application.DoubleValue the <inner> from <sum>.
+    Extract the <answer> from the <inner: doubled>.
+
+    Return an <OK: status> with { value: <answer> }.
+}
+
+(Application-Start: Custom Actions Demo) {
+    Log "=== User-Defined Actions Demo (ARO-0081) ===" to the <console>.
+
+    (* Sugar form: `from 5` — works because DoubleValue declares `takes <number>` *)
+    Application.DoubleValue the <d> from 5.
+    Extract the <doubled> from the <d: doubled>.
+    Log <doubled> to the <console>.   (* prints 10 *)
+
+    (* Object form: `with { ... }` — always works *)
+    Application.DoubleValue the <second> with { number: 7 }.
+    Extract the <second-doubled> from the <second: doubled>.
+    Log <second-doubled> to the <console>.   (* prints 14 *)
+
+    (* Composed call: SumAndDouble internally calls DoubleValue *)
+    Application.SumAndDouble the <answer> with { a: 3, b: 4 }.
+    Extract the <total> from the <answer: value>.
+    Log <total> to the <console>.   (* prints 14 *)
+
+    Return an <OK: status> for the <startup>.
+}

--- a/Proposals/ARO-0081-user-defined-actions.md
+++ b/Proposals/ARO-0081-user-defined-actions.md
@@ -1,6 +1,6 @@
 # ARO-0081: User-Defined Actions
 
-- **Status:** Draft
+- **Status:** Accepted (implemented in [Issue #224](https://git.ausdertechnik.de/arolang/aro/-/issues/224))
 - **Author:** ARO Language Team
 - **Created:** 2026-05-03
 - **Related:** ARO-0001 (Language Fundamentals), ARO-0004 (Actions), ARO-0005 (Application Architecture), ARO-0045 (Package Manager — plugin handles)
@@ -117,22 +117,25 @@ If an action does not declare `takes`, callers must use `with { ... }`. Calling 
 
 ### 5. Output contract
 
-The action returns its result via the standard `Return ... with ...` form. The result variable bound at the call site holds the **entire returned object** — i.e., a record with the status field and the `with` payload merged:
+The action returns its result via the standard `Return ... with ...` form. The result variable bound at the call site holds the **entire returned object** — `status`, optional `reason`, and every field of the `with` payload, all flattened into one dict:
 
 ```aro
 (DoubleValue: Action takes <number>) {
     Extract the <n> from the <input: number>.
-    Compute the <result> from <n> * 2.
-    Return an <OK: status> with <result>.
+    Compute the <doubled> from <n> * 2.
+    (* Use the object-literal form so the caller can pull a named field *)
+    Return an <OK: status> with { doubled: <doubled> }.
 }
 
 (* caller *)
 Application.DoubleValue the <d> from 5.
-(* <d> is now { status: "OK", result: 10 } *)
-Extract the <doubled> from the <d: result>.
+(* <d> is now { status: "OK", doubled: 10 } *)
+Extract the <result> from the <d: doubled>.
 ```
 
 The caller always uses `Extract` to pull individual fields. This matches the plugin-action shape (see `Examples/GreetingPlugin/main.aro`) and keeps one mental model for all callable surfaces.
+
+> **Note:** when the body uses `Return an <OK: status> with <variable>` and `<variable>` resolves to a primitive (Int/Double/Bool/String), Return places the value under the `value` key — i.e. callers extract via `<d: value>`. Use the object-literal form `with { name: <variable> }` when you want a specific field name.
 
 ### 6. Body restrictions
 
@@ -165,13 +168,15 @@ No imports, no manifests, no aro.yaml entries are required. This matches how eve
 
 ## Worked Example
 
+See `Examples/UserDefinedActions/main.aro` for the runnable version.
+
 ```aro
 (* math.aro *)
 
 (DoubleValue: Action takes <number>) {
     Extract the <n> from the <input: number>.
-    Compute the <result> from <n> * 2.
-    Return an <OK: status> with <result>.
+    Compute the <doubled> from <n> * 2.
+    Return an <OK: status> with { doubled: <doubled> }.
 }
 
 (SumAndDouble: Action) {
@@ -180,30 +185,38 @@ No imports, no manifests, no aro.yaml entries are required. This matches how eve
     Compute the <sum> from <a> + <b>.
 
     (* Compose with another user-defined action *)
-    Application.DoubleValue the <doubled-result> from <sum>.
-    Extract the <result> from the <doubled-result: result>.
+    Application.DoubleValue the <inner> from <sum>.
+    Extract the <answer> from the <inner: doubled>.
 
-    Return an <OK: status> with <result>.
+    Return an <OK: status> with { value: <answer> }.
 }
 
 (* main.aro *)
 
 (Application-Start: Math Demo) {
     Application.SumAndDouble the <answer> with { a: 3, b: 4 }.
-    Extract the <value> from the <answer: result>.
-    Log <value> to the <console>.   (* prints 14 *)
+    Extract the <total> from the <answer: value>.
+    Log <total> to the <console>.   (* prints 14 *)
     Return an <OK: status> for the <startup>.
 }
 ```
 
 ---
 
-## Implementation Notes
+## Implementation Notes (as shipped)
 
-- **Parser**: extend feature set header to accept `Action [takes <ident[: Type]>]`. Reject `takes` for any other activity.
-- **Semantic analysis**: build a global `UserActionRegistry` keyed by name during the existing application-load pass; emit duplicate-name and unknown-call diagnostics there.
-- **Runtime**: implement a single `UserDefinedActionHost` that implements `ActionImplementation`, registered for every name in `UserActionRegistry`. On execution it constructs a fresh `ExecutionContext` for the callee, binds `<input>` to the argument object, runs the body via the existing `FeatureSetExecutor`, and returns the returned object.
-- **Framework-variable enforcement**: piggyback on the existing symbol resolution path — when the executor's context has no `request`/`event`/etc. bindings (because they were never installed for an `Action` invocation), references already fail. Promote that to a compile-time check by tagging known framework names.
+- **Parser** (`Sources/AROParser/Parser.swift`): the feature-set header now recognises `Action takes <ident[: Type]>`. The activity slot is folded by the existing identifier-sequence reader and `Parser.splitUserActionHeader` decomposes it back into `(activity, takes, type)`. The takes field is stored as `userActionTakesField` / `userActionTakesType` on `FeatureSet`.
+- **Semantic analysis** (`Sources/AROParser/UserActionAnalyzer.swift`, `Sources/AROParser/UserActionRegistry.swift`): a single pass builds a `UserActionRegistry` keyed by name and runs validation:
+  - duplicate-name detection,
+  - unknown `Application.<Name>` calls,
+  - `from <value>` against an action without `takes`,
+  - framework-variable access (`<request>`, `<event>`, `<pathParameters>`, `<queryParameters>`, `<response>`) inside an Action body.
+- **Runtime** (`Sources/ARORuntime/Actions/UserDefinedActionHost.swift`): a single `UserDefinedActionHost` is constructed by `ExecutionEngine.execute` and registers every action under the verb `Application.<Name>` via `ActionRegistry.registerDynamic`. The handler:
+  - reads `_with_` / `_expression_` / `_literal_` **locally** on the caller's context (parent-walk would leak the outer call's input into nested calls),
+  - synthesises `<input>` from the sugar field when present,
+  - spawns a fresh `RuntimeContext` parented to the caller (services and globals stay accessible; framework variables are not copied),
+  - runs the body via the standard `FeatureSetExecutor`,
+  - flattens the resulting `Response` into `[String: Sendable]` so callers `Extract` fields exactly like plugin actions.
 - **No new ABI work**: user-defined actions are pure ARO; no plugin SDK changes are required.
 
 ## Future Extensions (out of scope)

--- a/Sources/AROParser/AST.swift
+++ b/Sources/AROParser/AST.swift
@@ -72,21 +72,49 @@ public struct FeatureSet: ASTNode {
     public let businessActivity: String
     public let statements: [Statement]
     public let whenCondition: (any Expression)?
+    /// User-defined action sugar slot (ARO-0081).
+    ///
+    /// When the activity is `Action`, the optional `takes <field[: Type]>` clause
+    /// in the header declares a single positional parameter that callers may pass
+    /// using `from <value>`. When non-nil this feature set is callable as
+    /// `Application.<name>` and `from <value>` synthesises an input object with
+    /// `{ field: value }`.
+    public let userActionTakesField: String?
+    /// Optional type annotation for the `takes` field (e.g. "Integer").
+    public let userActionTakesType: String?
     public let span: SourceSpan
 
-    public init(name: String, businessActivity: String, statements: [Statement], whenCondition: (any Expression)? = nil, span: SourceSpan) {
+    public init(
+        name: String,
+        businessActivity: String,
+        statements: [Statement],
+        whenCondition: (any Expression)? = nil,
+        userActionTakesField: String? = nil,
+        userActionTakesType: String? = nil,
+        span: SourceSpan
+    ) {
         self.name = name
         self.businessActivity = businessActivity
         self.statements = statements
         self.whenCondition = whenCondition
+        self.userActionTakesField = userActionTakesField
+        self.userActionTakesType = userActionTakesType
         self.span = span
     }
 
     public var description: String {
         let whenDesc = whenCondition != nil ? " when ..." : ""
-        return "FeatureSet(\(name): \(businessActivity)\(whenDesc), \(statements.count) statements)"
+        let takesDesc = userActionTakesField.map { " takes <\($0)>" } ?? ""
+        return "FeatureSet(\(name): \(businessActivity)\(takesDesc)\(whenDesc), \(statements.count) statements)"
     }
-    
+
+    /// True when this feature set is a user-defined action (ARO-0081).
+    /// User-defined actions live under the `Application.` handle and are invoked
+    /// like plugin actions: `Application.<Name> the <result> with { ... }.`
+    public var isUserAction: Bool {
+        businessActivity == "Action"
+    }
+
     public func accept<V: ASTVisitor>(_ visitor: V) throws -> V.Result {
         try visitor.visit(self)
     }

--- a/Sources/AROParser/Parser.swift
+++ b/Sources/AROParser/Parser.swift
@@ -126,13 +126,19 @@ public final class Parser {
         }
         
         try expect(.colon, message: "':'")
-        
+
         // Parse business activity (space-separated identifiers)
-        let activity = try parseIdentifierSequence()
-        if activity.isEmpty {
+        let rawActivity = try parseIdentifierSequence()
+        if rawActivity.isEmpty {
             throw ParserError.missingBusinessActivity(at: peek().span.start)
         }
-        
+
+        // ARO-0081: User-defined actions use `Action [takes <field[: Type]>]` headers.
+        // `parseIdentifierSequence` collapses the header to "Action takes<field>" or
+        // "Action takes<field:Type>" — the angle-bracket suffix logic concatenates
+        // tokens between `<` and `>` without spaces. Recover the structured form here.
+        let (activity, userActionTakesField, userActionTakesType) = Self.splitUserActionHeader(rawActivity)
+
         try expect(.rightParen, message: "')'")
 
         // Parse optional when/where clause for feature set guards (e.g., Handler when/where condition)
@@ -170,8 +176,31 @@ public final class Parser {
             businessActivity: activity,
             statements: statements,
             whenCondition: whenCondition,
+            userActionTakesField: userActionTakesField,
+            userActionTakesType: userActionTakesType,
             span: startToken.span.merged(with: endToken.span)
         )
+    }
+
+    /// Decompose a raw activity string into `(activity, takesField, takesType)`.
+    ///
+    /// The lexer + `parseIdentifierSequence` collapses `Action takes <number: Integer>`
+    /// to `"Action takes<number:Integer>"`. This helper restores the structured
+    /// form and rejects malformed `takes` clauses without affecting non-Action
+    /// activities (which pass through unchanged).
+    static func splitUserActionHeader(_ raw: String) -> (activity: String, takes: String?, type: String?) {
+        let prefix = "Action takes<"
+        if raw.hasPrefix(prefix), raw.hasSuffix(">") {
+            let inner = String(raw.dropFirst(prefix.count).dropLast())
+            if let colonIdx = inner.firstIndex(of: ":") {
+                let field = String(inner[..<colonIdx]).trimmingCharacters(in: .whitespaces)
+                let typeName = String(inner[inner.index(after: colonIdx)...]).trimmingCharacters(in: .whitespaces)
+                return ("Action", field.isEmpty ? nil : field, typeName.isEmpty ? nil : typeName)
+            }
+            let field = inner.trimmingCharacters(in: .whitespaces)
+            return ("Action", field.isEmpty ? nil : field, nil)
+        }
+        return (raw, nil, nil)
     }
     
     // MARK: - Statement Parsing

--- a/Sources/AROParser/SemanticAnalyzer.swift
+++ b/Sources/AROParser/SemanticAnalyzer.swift
@@ -133,6 +133,14 @@ public struct AnalyzedProgram: Sendable {
     /// Feature sets indexed by name for O(1) lookup (e.g. by HTTP operationId).
     public let byName: [String: AnalyzedFeatureSet]
 
+    /// Catalog of user-defined actions discovered in this program (ARO-0081).
+    /// Built during `analyze()` and consumed by:
+    /// - subsequent semantic-analysis passes (duplicate names, unknown calls,
+    ///   `from <value>` against actions without a `takes` clause);
+    /// - the runtime, which registers `Application.<Name>` verbs from this map
+    ///   before the entry point runs.
+    public let userActions: UserActionRegistry
+
     // MARK: - Pre-computed handler category indexes
 
     /// Feature sets whose business activity contains "Socket Event Handler".
@@ -156,10 +164,16 @@ public struct AnalyzedProgram: Sendable {
     /// Domain event handlers: contain " Handler" but not socket/websocket/file/keypress/application-end.
     public let domainHandlers: [AnalyzedFeatureSet]
 
-    public init(program: Program, featureSets: [AnalyzedFeatureSet], globalRegistry: GlobalSymbolRegistry) {
+    public init(
+        program: Program,
+        featureSets: [AnalyzedFeatureSet],
+        globalRegistry: GlobalSymbolRegistry,
+        userActions: UserActionRegistry = UserActionRegistry()
+    ) {
         self.program = program
         self.featureSets = featureSets
         self.globalRegistry = globalRegistry
+        self.userActions = userActions
         self.byActivity = Dictionary(grouping: featureSets, by: { $0.featureSet.businessActivity })
         var nameIndex: [String: AnalyzedFeatureSet] = [:]
         for fs in featureSets { nameIndex[fs.featureSet.name] = fs }
@@ -255,11 +269,16 @@ public final class SemanticAnalyzer {
         let dataFlow = DataFlowAnalyzer(diagnostics: diagnostics)
         let codeQuality = CodeQualityValidator(diagnostics: diagnostics)
         let events = EventAnalyzer(diagnostics: diagnostics)
+        let userActionAnalyzer = UserActionAnalyzer(diagnostics: diagnostics)
 
         var analyzedSets: [AnalyzedFeatureSet] = []
 
         // First pass: check for duplicate names
         dataFlow.detectDuplicateFeatureSetNames(program.featureSets)
+
+        // ARO-0081: build the user-action registry before per-feature-set analysis
+        // so subsequent passes can validate `Application.<Name>` calls.
+        let userActions = userActionAnalyzer.buildRegistry(program.featureSets)
 
         // Second pass: analyze each feature set
         for featureSet in program.featureSets {
@@ -286,10 +305,16 @@ public final class SemanticAnalyzer {
         // Fifth pass: detect orphaned event emissions
         events.detectOrphanedEventEmissions(analyzedSets)
 
+        // ARO-0081: validate `Application.<Name>` calls and framework-variable
+        // access inside Action bodies. Done last so duplicate-name diagnostics
+        // emitted by `buildRegistry` come before call-site diagnostics.
+        userActionAnalyzer.validateCalls(in: program.featureSets, registry: userActions)
+
         return AnalyzedProgram(
             program: program,
             featureSets: analyzedSets,
-            globalRegistry: globalRegistry
+            globalRegistry: globalRegistry,
+            userActions: userActions
         )
     }
 }

--- a/Sources/AROParser/UserActionAnalyzer.swift
+++ b/Sources/AROParser/UserActionAnalyzer.swift
@@ -1,0 +1,157 @@
+// ============================================================
+// UserActionAnalyzer.swift
+// AROParser - Validation passes for user-defined actions (ARO-0081)
+// ============================================================
+//
+// This validator runs alongside the data-flow analyzer to:
+//   1. Discover every `Action` feature set and build a UserActionRegistry.
+//   2. Detect duplicate action names across the application.
+//   3. Detect `Application.<Name>` calls that do not resolve to a known action.
+//   4. Detect `from <value>` sugar against an action without a `takes` clause.
+//   5. Detect framework-variable access (`<request>`, `<event>`, …) inside an
+//      Action body, which is not allowed because actions are synchronous and
+//      have no event/request context.
+
+import Foundation
+
+public final class UserActionAnalyzer {
+    private let diagnostics: DiagnosticCollector
+
+    public init(diagnostics: DiagnosticCollector) {
+        self.diagnostics = diagnostics
+    }
+
+    // MARK: - Registry Construction
+
+    /// Walk the program and build a `UserActionRegistry` keyed by action name.
+    /// Emits a duplicate-name diagnostic when two `Action` feature sets share
+    /// the same name; the first declaration wins (later ones are skipped).
+    public func buildRegistry(_ featureSets: [FeatureSet]) -> UserActionRegistry {
+        var actions: [String: UserActionInfo] = [:]
+
+        for fs in featureSets where fs.isUserAction {
+            if let existing = actions[fs.name] {
+                diagnostics.error(
+                    "Duplicate user-defined action 'Application.\(fs.name)'",
+                    at: fs.span.start,
+                    hints: [
+                        "An action with this name was already declared at line \(existing.span.start.line)",
+                        "User-defined action names are unique application-wide",
+                    ]
+                )
+                continue
+            }
+
+            actions[fs.name] = UserActionInfo(
+                name: fs.name,
+                takesField: fs.userActionTakesField,
+                takesType: fs.userActionTakesType,
+                span: fs.span
+            )
+        }
+
+        return UserActionRegistry(actions: actions)
+    }
+
+    // MARK: - Call-Site Validation
+
+    /// Walk every statement in every feature set and check `Application.<Name>`
+    /// calls against the registry. Also enforces the body restrictions for
+    /// Action feature sets (no framework variables).
+    public func validateCalls(in featureSets: [FeatureSet], registry: UserActionRegistry) {
+        for fs in featureSets {
+            let isInsideAction = fs.isUserAction
+            visit(fs.statements, isInsideAction: isInsideAction, registry: registry)
+        }
+    }
+
+    private func visit(_ statements: [Statement], isInsideAction: Bool, registry: UserActionRegistry) {
+        for statement in statements {
+            switch statement {
+            case let aro as AROStatement:
+                validateApplicationCall(aro, registry: registry)
+                if isInsideAction {
+                    validateNoFrameworkVariables(aro)
+                }
+            case let pipeline as PipelineStatement:
+                for stage in pipeline.stages {
+                    validateApplicationCall(stage, registry: registry)
+                    if isInsideAction {
+                        validateNoFrameworkVariables(stage)
+                    }
+                }
+            case let forEach as ForEachLoop:
+                visit(forEach.body, isInsideAction: isInsideAction, registry: registry)
+            case let rangeLoop as RangeLoop:
+                visit(rangeLoop.body, isInsideAction: isInsideAction, registry: registry)
+            case let whileLoop as WhileLoop:
+                visit(whileLoop.body, isInsideAction: isInsideAction, registry: registry)
+            case let match as MatchStatement:
+                for clause in match.cases {
+                    visit(clause.body, isInsideAction: isInsideAction, registry: registry)
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    /// Validate an `Application.<Name>` call. Non-Application calls fall through.
+    private func validateApplicationCall(_ statement: AROStatement, registry: UserActionRegistry) {
+        let verb = statement.action.verb
+        guard let actionName = UserActionRegistry.actionName(fromCallVerb: verb) else { return }
+
+        guard let info = registry.info(for: actionName) else {
+            let known = registry.allNames
+            var hints: [String] = []
+            if !known.isEmpty {
+                hints.append("Known user-defined actions: " + known.map { "Application.\($0)" }.joined(separator: ", "))
+            } else {
+                hints.append("No user-defined actions are declared in this application")
+                hints.append("Declare one with `(MyAction: Action) { ... }`")
+            }
+            diagnostics.error(
+                "Unknown user-defined action 'Application.\(actionName)'",
+                at: statement.action.span.start,
+                hints: hints
+            )
+            return
+        }
+
+        // `from <value>` is only valid when the callee declares `takes <field>`.
+        // The parser folds `from <value>` into preposition `.from` plus an
+        // expression (object base = `_expression_`) or a literal (object base = `_literal_`).
+        if statement.object.preposition == .from && info.takesField == nil {
+            diagnostics.error(
+                "Cannot call 'Application.\(actionName)' with `from <value>`",
+                at: statement.action.span.start,
+                hints: [
+                    "'\(actionName)' does not declare a `takes` clause in its header",
+                    "Use `with { … }` to pass an input object, or add `takes <field>` to the header to allow positional calls",
+                ]
+            )
+        }
+    }
+
+    /// Reject references to framework variables inside an `Action` body.
+    /// Framework variables are bound only by HTTP routes, event handlers, and
+    /// lifecycle feature sets — they have no value here.
+    private func validateNoFrameworkVariables(_ statement: AROStatement) {
+        // Object base
+        let objectBase = statement.object.noun.base
+        if UserActionFrameworkVariables.contains(objectBase) {
+            diagnostics.error(
+                "Framework variable '<\(objectBase)>' is not available inside a user-defined action",
+                at: statement.object.noun.span.start,
+                hints: [
+                    "User-defined actions are synchronous transformations with no event or request context",
+                    "Pass the data you need via the `<input>` object instead",
+                ]
+            )
+        }
+
+        // Object specifier (e.g. `<request: body>` — checks the base, which is `request`).
+        // The check above already covers this because `noun.base == "request"`.
+        // But `<event: user>` style: also covered, because the base is `event`.
+    }
+}

--- a/Sources/AROParser/UserActionRegistry.swift
+++ b/Sources/AROParser/UserActionRegistry.swift
@@ -1,0 +1,108 @@
+// ============================================================
+// UserActionRegistry.swift
+// AROParser - User-Defined Action Catalogue (ARO-0081)
+// ============================================================
+//
+// User-defined actions are feature sets whose business activity is exactly
+// `Action`. They are callable application-wide as `Application.<Name>` using
+// the same call-site syntax as plugin actions. This registry indexes them
+// during semantic analysis so:
+//
+// - The runtime can look up a name → feature set mapping at registration time.
+// - The semantic analyser can flag duplicate-name and unknown-call diagnostics
+//   before the program ever runs.
+
+import Foundation
+
+// MARK: - UserActionInfo
+
+/// Metadata for a user-defined action discovered during semantic analysis.
+public struct UserActionInfo: Sendable, Equatable {
+    /// Action name as written in the feature set header (e.g. "DoubleValue").
+    /// Callers invoke as `Application.<name>` (case-sensitive).
+    public let name: String
+
+    /// Sugar slot field declared via `takes <field>` in the header, if any.
+    /// When non-nil, callers may use `from <value>` to bind `<value>` to this
+    /// field on `<input>`.
+    public let takesField: String?
+
+    /// Optional type annotation for the takes field (e.g. "Integer").
+    public let takesType: String?
+
+    /// Source location of the action's declaration, for duplicate-name diagnostics.
+    public let span: SourceSpan
+
+    public init(name: String, takesField: String?, takesType: String?, span: SourceSpan) {
+        self.name = name
+        self.takesField = takesField
+        self.takesType = takesType
+        self.span = span
+    }
+}
+
+// MARK: - UserActionRegistry
+
+/// Application-wide registry of user-defined actions.
+///
+/// Built once per `analyze()` pass and exposed on `AnalyzedProgram` so both
+/// further analysis passes and the runtime registration step can consult it
+/// without re-walking the AST.
+public struct UserActionRegistry: Sendable, Equatable {
+    /// Action name → metadata. Keys are case-sensitive, matching the header.
+    public let actions: [String: UserActionInfo]
+
+    public init(actions: [String: UserActionInfo] = [:]) {
+        self.actions = actions
+    }
+
+    /// Look up an action by its bare name (e.g. `"DoubleValue"`).
+    public func info(for name: String) -> UserActionInfo? {
+        actions[name]
+    }
+
+    /// Look up an action via the call-site verb (e.g. `"Application.DoubleValue"`).
+    public func info(forCallVerb verb: String) -> UserActionInfo? {
+        guard let bare = Self.actionName(fromCallVerb: verb) else { return nil }
+        return actions[bare]
+    }
+
+    /// Decompose a call verb. Returns the bare action name when `verb` matches
+    /// `Application.<Name>`, otherwise nil.
+    public static func actionName(fromCallVerb verb: String) -> String? {
+        let prefix = "Application."
+        guard verb.hasPrefix(prefix) else { return nil }
+        let bare = String(verb.dropFirst(prefix.count))
+        return bare.isEmpty ? nil : bare
+    }
+
+    /// Sorted list of all known action names (used in diagnostic hints).
+    public var allNames: [String] {
+        actions.keys.sorted()
+    }
+
+    public var isEmpty: Bool { actions.isEmpty }
+}
+
+// MARK: - Framework Variables
+
+/// Variable names that are *only* available inside event handlers, HTTP routes,
+/// and lifecycle feature sets. Referencing them from inside an `Action` body is
+/// a compile error because user-defined actions are synchronous transformations
+/// with no event/request context.
+public enum UserActionFrameworkVariables {
+    /// The set the analyser checks against. Lower-cased for case-insensitive
+    /// comparison against object/specifier identifiers.
+    public static let names: Set<String> = [
+        "request",
+        "response",
+        "event",
+        "pathparameters",
+        "queryparameters",
+    ]
+
+    /// True if the given identifier is a framework variable.
+    public static func contains(_ identifier: String) -> Bool {
+        names.contains(identifier.lowercased())
+    }
+}

--- a/Sources/ARORuntime/Actions/UserDefinedActionHost.swift
+++ b/Sources/ARORuntime/Actions/UserDefinedActionHost.swift
@@ -1,0 +1,223 @@
+// ============================================================
+// UserDefinedActionHost.swift
+// ARO Runtime - Host for user-defined actions (ARO-0081)
+// ============================================================
+//
+// Registers a dynamic action verb in `ActionRegistry` for every user-defined
+// action discovered by `SemanticAnalyzer`. When invoked from an ARO statement,
+// the host:
+//   1. Builds an `<input>` object from the call site (`with { … }`, sugar
+//      `from <value>`, or a variable reference).
+//   2. Spawns a fresh `RuntimeContext` parented to the caller (so services and
+//      published symbols remain accessible) but with no event/request data.
+//   3. Runs the action body via `FeatureSetExecutor`.
+//   4. Flattens the response into a `[String: Sendable]` dict that callers
+//      pull fields from with `Extract the <field> from the <result: field>.`,
+//      mirroring plugin-action semantics.
+
+import Foundation
+import AROParser
+
+/// Discovers and registers every user-defined action under `Application.<Name>`.
+///
+/// Built once per application run from the live `AnalyzedProgram`. The host
+/// keeps a strong reference to each `AnalyzedFeatureSet` so the registered
+/// dynamic handler can run it without re-resolving by name on every call.
+public final class UserDefinedActionHost: @unchecked Sendable {
+    /// The name surfaced to `ActionRegistry.unregisterPlugin(_:)` so all
+    /// user-defined actions can be cleared together (mirrors the plugin path).
+    public static let pluginName = "_user_defined_actions_"
+
+    private let analyzedProgram: AnalyzedProgram
+    private let actionsByName: [String: AnalyzedFeatureSet]
+    private let globalSymbols: GlobalSymbolStorage
+    private let actionRegistryRef: ActionRegistry
+    private let eventBusRef: EventBus
+
+    public init(
+        analyzedProgram: AnalyzedProgram,
+        globalSymbols: GlobalSymbolStorage,
+        actionRegistry: ActionRegistry = .shared,
+        eventBus: EventBus = .shared
+    ) {
+        self.analyzedProgram = analyzedProgram
+        self.globalSymbols = globalSymbols
+        self.actionRegistryRef = actionRegistry
+        self.eventBusRef = eventBus
+
+        var byName: [String: AnalyzedFeatureSet] = [:]
+        for fs in analyzedProgram.featureSets where fs.featureSet.isUserAction {
+            byName[fs.featureSet.name] = fs
+        }
+        self.actionsByName = byName
+    }
+
+    /// Whether any user-defined actions were discovered.
+    public var isEmpty: Bool { actionsByName.isEmpty }
+
+    /// Names of registered actions (for diagnostics and tests).
+    public var actionNames: [String] { actionsByName.keys.sorted() }
+
+    /// Register every user-defined action under the verb `Application.<Name>`.
+    /// Safe to call multiple times — `unregisterPlugin` cleans up previous
+    /// registrations under the same plugin name.
+    public func register() async {
+        for (name, analyzed) in actionsByName {
+            let verb = "Application.\(name)"
+            let captured = analyzed
+            let capturedHost = self
+            await actionRegistryRef.registerDynamic(
+                verb: verb,
+                handler: { result, object, context in
+                    try await capturedHost.invoke(
+                        analyzed: captured,
+                        result: result,
+                        object: object,
+                        context: context
+                    )
+                },
+                pluginName: Self.pluginName
+            )
+        }
+    }
+
+    /// Unregister every user-defined action. Used when reloading a program
+    /// (currently only by tests) so a stale handler can't outlive its program.
+    public func unregister() async {
+        await actionRegistryRef.unregisterPlugin(Self.pluginName)
+    }
+
+    // MARK: - Invocation
+
+    /// Run a user-defined action. Public so tests can drive it directly.
+    public func invoke(
+        analyzed: AnalyzedFeatureSet,
+        result: ResultDescriptor,
+        object: ObjectDescriptor,
+        context: ExecutionContext
+    ) async throws -> any Sendable {
+        let input = buildInput(
+            featureSet: analyzed.featureSet,
+            object: object,
+            context: context
+        )
+
+        // Spawn a child context for the callee. Parenting to the caller keeps
+        // services and published globals accessible. We deliberately do NOT
+        // copy framework variables (event/request/pathParameters) — actions
+        // are synchronous transformations with no event/request context.
+        let childContext = RuntimeContext(
+            featureSetName: analyzed.featureSet.name,
+            businessActivity: analyzed.featureSet.businessActivity,
+            parent: context
+        )
+
+        // Bind the input object so the action body can `Extract the <field>
+        // from the <input: field>` exactly like a plugin/event handler.
+        childContext.bind("input", value: input)
+
+        // Run the action body. Reuse the same actionRegistry/eventBus/globalSymbols
+        // the host was constructed with so `Publish` and event emission stay
+        // visible application-wide.
+        let executor = FeatureSetExecutor(
+            actionRegistry: actionRegistryRef,
+            eventBus: eventBusRef,
+            globalSymbols: globalSymbols
+        )
+        let response = try await executor.execute(analyzed, context: childContext)
+
+        // Flatten the response so callers extract fields from the result
+        // variable directly (same shape plugin actions return).
+        return flatten(response: response)
+    }
+
+    // MARK: - Input Construction
+
+    /// Build the `<input>` object from the call site, mirroring plugin actions
+    /// but tightening the contract to what user-defined actions support.
+    ///
+    /// Resolution order (first match wins):
+    /// 1. `_with_` is bound LOCALLY and is an object: pass it through unchanged.
+    /// 2. Sugar form: `_expression_` / `_literal_` is bound locally AND the
+    ///    action declares `takes <field>` — wrap as `{ field: value }`.
+    /// 3. Object base resolves to an existing object/dict — pass through.
+    /// 4. Otherwise return an empty dict; downstream `Extract` calls will
+    ///    surface a clear "field not found" error.
+    ///
+    /// **Local-only lookup is critical** for nested calls: per-statement
+    /// transients (`_with_`, `_expression_`, `_literal_`) stay bound on the
+    /// caller's context for the duration of the statement, so the parent-walk
+    /// in `resolveAny` would otherwise leak the outer call's input into the
+    /// nested call.
+    func buildInput(
+        featureSet: FeatureSet,
+        object: ObjectDescriptor,
+        context: ExecutionContext
+    ) -> [String: any Sendable] {
+        // 1. `with { ... }` — already evaluated by the executor and bound to _with_.
+        if let withDict = resolveLocal(context, "_with_") as? [String: any Sendable] {
+            return withDict
+        }
+
+        // 2. Sugar form: `from <value>` against an action that declared `takes`.
+        //    The parser routes literals to `_literal_` and expression results to
+        //    `_expression_`, with object.base set accordingly.
+        if let takesField = featureSet.userActionTakesField {
+            if let exprValue = resolveLocal(context, "_expression_") {
+                return [takesField: exprValue]
+            }
+            if let literal = resolveLocal(context, "_literal_") {
+                return [takesField: literal]
+            }
+            // Fallback: caller passed a bare variable like `from <count>` and
+            // the parser kept the object base as the variable name.
+            if let value = context.resolveAny(object.base) {
+                return [takesField: value]
+            }
+        }
+
+        // 3. Caller passed `with <args>` where <args> is an existing object.
+        if let resolved = context.resolveAny(object.base) as? [String: any Sendable] {
+            return resolved
+        }
+
+        // 4. Empty input. The action body's `Extract` calls will fail with a
+        //    descriptive error if it actually needs anything.
+        return [:]
+    }
+
+    /// Look up `name` in the current context only, ignoring parents.
+    /// Used for the per-statement transients (`_with_`, `_expression_`,
+    /// `_literal_`) so a nested call doesn't accidentally pick up the
+    /// outer caller's bindings.
+    private func resolveLocal(_ context: ExecutionContext, _ name: String) -> (any Sendable)? {
+        guard let runtimeCtx = context as? RuntimeContext else {
+            // Non-RuntimeContext: fall back to the regular lookup. This path
+            // exists only for synthetic test contexts.
+            return context.resolveAny(name)
+        }
+        guard runtimeCtx.existsLocally(name) else { return nil }
+        return runtimeCtx.resolveAny(name)
+    }
+
+    // MARK: - Output Flattening
+
+    /// Convert a `Response` into the flat dict shape callers see at the call site.
+    /// Matches the plugin convention: `status` and `reason` become top-level
+    /// keys alongside whatever fields `Return ... with <data>.` produced.
+    private func flatten(response: Response) -> [String: any Sendable] {
+        var dict: [String: any Sendable] = [
+            "status": response.status,
+        ]
+        if !response.reason.isEmpty {
+            dict["reason"] = response.reason
+        }
+        for (key, anySendable) in response.data {
+            if let value: any Sendable = anySendable.get() {
+                dict[key] = value
+            }
+        }
+        return dict
+    }
+}
+

--- a/Sources/ARORuntime/Core/ExecutionEngine.swift
+++ b/Sources/ARORuntime/Core/ExecutionEngine.swift
@@ -100,6 +100,18 @@ public actor ExecutionEngine {
             throw ActionError.entryPointNotFound(entryPoint)
         }
 
+        // ARO-0081: Register user-defined actions before the entry point runs.
+        // This makes `Application.<Name>` callable from anywhere in the program,
+        // including from inside Application-Start itself. The host is kept
+        // alive for the duration of the run via the engine's strong reference.
+        let userActionHost = UserDefinedActionHost(
+            analyzedProgram: program,
+            globalSymbols: globalSymbols,
+            actionRegistry: actionRegistry,
+            eventBus: eventBus
+        )
+        await userActionHost.register()
+
         // Emit application start event
         eventBus.publish(ApplicationStartedEvent(applicationName: entryPoint))
 

--- a/Tests/AROParserTests/UserActionTests.swift
+++ b/Tests/AROParserTests/UserActionTests.swift
@@ -1,0 +1,233 @@
+// ============================================================
+// UserActionTests.swift
+// AROParser - Tests for user-defined actions (ARO-0081)
+// ============================================================
+
+import Testing
+import Foundation
+@testable import AROParser
+
+@Suite("User-Defined Actions (ARO-0081)")
+struct UserActionTests {
+
+    // MARK: - Parser
+
+    @Suite("Parser")
+    struct ParserTests {
+
+        @Test("Plain Action header without takes clause")
+        func plainAction() throws {
+            let source = """
+            (DoubleValue: Action) {
+                Return an <OK: status> with <result>.
+            }
+            """
+            let program = try Parser.parse(source)
+            #expect(program.featureSets.count == 1)
+            let fs = program.featureSets[0]
+            #expect(fs.businessActivity == "Action")
+            #expect(fs.isUserAction == true)
+            #expect(fs.userActionTakesField == nil)
+            #expect(fs.userActionTakesType == nil)
+        }
+
+        @Test("Action header with takes <field>")
+        func actionWithTakesField() throws {
+            let source = """
+            (DoubleValue: Action takes <number>) {
+                Return an <OK: status> with <result>.
+            }
+            """
+            let program = try Parser.parse(source)
+            let fs = program.featureSets[0]
+            #expect(fs.businessActivity == "Action")
+            #expect(fs.isUserAction == true)
+            #expect(fs.userActionTakesField == "number")
+            #expect(fs.userActionTakesType == nil)
+        }
+
+        @Test("Action header with takes <field: Type>")
+        func actionWithTakesFieldAndType() throws {
+            let source = """
+            (DoubleValue: Action takes <number: Integer>) {
+                Return an <OK: status> with <result>.
+            }
+            """
+            let program = try Parser.parse(source)
+            let fs = program.featureSets[0]
+            #expect(fs.userActionTakesField == "number")
+            #expect(fs.userActionTakesType == "Integer")
+        }
+
+        @Test("Non-Action feature sets are not user actions")
+        func nonActionIsNotUserAction() throws {
+            let source = """
+            (Application-Start: Demo) {
+                Return an <OK: status> for the <startup>.
+            }
+            """
+            let program = try Parser.parse(source)
+            let fs = program.featureSets[0]
+            #expect(fs.isUserAction == false)
+            #expect(fs.userActionTakesField == nil)
+        }
+    }
+
+    // MARK: - splitUserActionHeader
+
+    @Suite("Header Decomposition")
+    struct HeaderTests {
+
+        @Test("Plain Action passes through")
+        func plainActionPassesThrough() {
+            let (activity, takes, type) = Parser.splitUserActionHeader("Action")
+            #expect(activity == "Action")
+            #expect(takes == nil)
+            #expect(type == nil)
+        }
+
+        @Test("Action takes<number> splits cleanly")
+        func actionWithField() {
+            let (activity, takes, type) = Parser.splitUserActionHeader("Action takes<number>")
+            #expect(activity == "Action")
+            #expect(takes == "number")
+            #expect(type == nil)
+        }
+
+        @Test("Action takes<number:Integer> recovers type")
+        func actionWithFieldAndType() {
+            let (activity, takes, type) = Parser.splitUserActionHeader("Action takes<number:Integer>")
+            #expect(activity == "Action")
+            #expect(takes == "number")
+            #expect(type == "Integer")
+        }
+
+        @Test("Unrelated activity is unchanged")
+        func unrelatedUnchanged() {
+            let (activity, takes, type) = Parser.splitUserActionHeader("UserCreated Handler")
+            #expect(activity == "UserCreated Handler")
+            #expect(takes == nil)
+            #expect(type == nil)
+        }
+    }
+
+    // MARK: - UserActionRegistry
+
+    @Suite("Registry")
+    struct RegistryTests {
+
+        @Test("actionName(fromCallVerb:) extracts the bare name")
+        func extractBareName() {
+            #expect(UserActionRegistry.actionName(fromCallVerb: "Application.DoubleValue") == "DoubleValue")
+            #expect(UserActionRegistry.actionName(fromCallVerb: "Greeting.Greet") == nil)
+            #expect(UserActionRegistry.actionName(fromCallVerb: "Compute") == nil)
+            #expect(UserActionRegistry.actionName(fromCallVerb: "Application.") == nil)
+        }
+
+        @Test("Registry built from program lists user actions")
+        func registryListsActions() {
+            let source = """
+            (DoubleValue: Action takes <number>) {
+                Return an <OK: status> with <result>.
+            }
+            (Halve: Action takes <number>) {
+                Return an <OK: status> with <result>.
+            }
+            (Application-Start: Demo) {
+                Return an <OK: status> for the <startup>.
+            }
+            """
+            let program = try? Parser.parse(source)
+            let analyzer = SemanticAnalyzer()
+            let analyzed = analyzer.analyze(program!)
+            #expect(analyzed.userActions.allNames == ["DoubleValue", "Halve"])
+            #expect(analyzed.userActions.info(for: "DoubleValue")?.takesField == "number")
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    @Suite("Diagnostics")
+    struct DiagnosticTests {
+
+        @Test("Duplicate action names emit an error")
+        func duplicateAction() {
+            let diagnostics = DiagnosticCollector()
+            let source = """
+            (DoubleValue: Action takes <number>) {
+                Return an <OK: status> with <result>.
+            }
+            (DoubleValue: Action) {
+                Return an <OK: status> with <result>.
+            }
+            """
+            let program = try? Parser.parse(source, diagnostics: diagnostics)
+            _ = SemanticAnalyzer(diagnostics: diagnostics).analyze(program!)
+            let messages = diagnostics.diagnostics.map { $0.message }
+            #expect(messages.contains { $0.contains("Duplicate user-defined action") })
+        }
+
+        @Test("Unknown Application.<Name> calls emit an error")
+        func unknownApplicationCall() {
+            let diagnostics = DiagnosticCollector()
+            let source = """
+            (Application-Start: Demo) {
+                Application.NoSuch the <x> with { a: 1 }.
+                Return an <OK: status> for the <startup>.
+            }
+            """
+            let program = try? Parser.parse(source, diagnostics: diagnostics)
+            _ = SemanticAnalyzer(diagnostics: diagnostics).analyze(program!)
+            let messages = diagnostics.diagnostics.map { $0.message }
+            #expect(messages.contains { $0.contains("Unknown user-defined action 'Application.NoSuch'") })
+        }
+
+        @Test("Sugar form against action without takes is rejected")
+        func sugarWithoutTakes() {
+            let diagnostics = DiagnosticCollector()
+            let source = """
+            (Plain: Action) {
+                Return an <OK: status> with <result>.
+            }
+            (Application-Start: Demo) {
+                Application.Plain the <x> from 5.
+                Return an <OK: status> for the <startup>.
+            }
+            """
+            let program = try? Parser.parse(source, diagnostics: diagnostics)
+            _ = SemanticAnalyzer(diagnostics: diagnostics).analyze(program!)
+            let messages = diagnostics.diagnostics.map { $0.message }
+            #expect(messages.contains { $0.contains("Cannot call 'Application.Plain' with `from <value>`") })
+        }
+
+        @Test("Framework variables inside Action body are rejected")
+        func frameworkVarRejected() {
+            let diagnostics = DiagnosticCollector()
+            let source = """
+            (BadAction: Action) {
+                Extract the <body> from the <request: body>.
+                Return an <OK: status> with <body>.
+            }
+            """
+            let program = try? Parser.parse(source, diagnostics: diagnostics)
+            _ = SemanticAnalyzer(diagnostics: diagnostics).analyze(program!)
+            let messages = diagnostics.diagnostics.map { $0.message }
+            #expect(messages.contains { $0.contains("Framework variable '<request>'") })
+        }
+
+        @Test("Framework variables outside Action body are allowed")
+        func frameworkVarAllowedElsewhere() {
+            let diagnostics = DiagnosticCollector()
+            let source = """
+            (createUser: User API) {
+                Extract the <body> from the <request: body>.
+                Return an <OK: status> with <body>.
+            }
+            """
+            let program = try? Parser.parse(source, diagnostics: diagnostics)
+            _ = SemanticAnalyzer(diagnostics: diagnostics).analyze(program!)
+            let messages = diagnostics.diagnostics.map { $0.message }
+            #expect(messages.allSatisfy { !$0.contains("Framework variable") })
+        }
+    }
+}

--- a/Tests/AROuntimeTests/UserDefinedActionTests.swift
+++ b/Tests/AROuntimeTests/UserDefinedActionTests.swift
@@ -1,0 +1,115 @@
+// ============================================================
+// UserDefinedActionTests.swift
+// ARO Runtime - End-to-end tests for user-defined actions (ARO-0081)
+// ============================================================
+
+import Foundation
+import Testing
+@testable import ARORuntime
+@testable import AROParser
+
+@Suite("User-Defined Actions Runtime (ARO-0081)")
+struct UserDefinedActionTests {
+
+    /// Compile and run a snippet, returning the analyzed program and the
+    /// response from `Application-Start`. We freshly construct
+    /// `ActionRegistry.shared`-bound state per test by registering and then
+    /// unregistering the user actions, so tests don't see each other's verbs.
+    private func runProgram(_ source: String) async throws -> (Response, AnalyzedProgram) {
+        let result = Compiler().compile(source)
+        #expect(result.diagnostics.allSatisfy { $0.severity != .error },
+                "Compilation produced unexpected errors: \(result.diagnostics.map(\.message))")
+        let runtime = Runtime()
+        let response = try await runtime.run(result.analyzedProgram)
+        // Clean up so the next test starts with a fresh registry.
+        let host = UserDefinedActionHost(
+            analyzedProgram: result.analyzedProgram,
+            globalSymbols: GlobalSymbolStorage()
+        )
+        await host.unregister()
+        return (response, result.analyzedProgram)
+    }
+
+    @Test("Sugar form passes single value to the takes field")
+    func sugarFormPassesValue() async throws {
+        let source = """
+        (DoubleValue: Action takes <number>) {
+            Extract the <n> from the <input: number>.
+            Compute the <doubled> from <n> * 2.
+            Return an <OK: status> with { doubled: <doubled> }.
+        }
+        (Application-Start: Demo) {
+            Application.DoubleValue the <d> from 5.
+            Extract the <doubled> from the <d: doubled>.
+            Publish as <out> <doubled>.
+            Return an <OK: status> for the <startup>.
+        }
+        """
+        let (response, _) = try await runProgram(source)
+        #expect(response.status == "OK")
+    }
+
+    @Test("Object form passes the dict directly")
+    func objectFormPassesDict() async throws {
+        let source = """
+        (Greet: Action) {
+            Extract the <name> from the <input: name>.
+            Return an <OK: status> with { greeting: <name> }.
+        }
+        (Application-Start: Demo) {
+            Application.Greet the <g> with { name: "World" }.
+            Extract the <greeting> from the <g: greeting>.
+            Return an <OK: status> for the <startup>.
+        }
+        """
+        let (response, _) = try await runProgram(source)
+        #expect(response.status == "OK")
+    }
+
+    @Test("Composed action calls compose correctly")
+    func composedActions() async throws {
+        let source = """
+        (DoubleValue: Action takes <number>) {
+            Extract the <n> from the <input: number>.
+            Compute the <doubled> from <n> * 2.
+            Return an <OK: status> with { doubled: <doubled> }.
+        }
+        (SumAndDouble: Action) {
+            Extract the <a> from the <input: a>.
+            Extract the <b> from the <input: b>.
+            Compute the <sum> from <a> + <b>.
+            Application.DoubleValue the <inner> from <sum>.
+            Extract the <answer> from the <inner: doubled>.
+            Return an <OK: status> with { value: <answer> }.
+        }
+        (Application-Start: Demo) {
+            Application.SumAndDouble the <r> with { a: 3, b: 4 }.
+            Extract the <total> from the <r: value>.
+            Return an <OK: status> for the <startup>.
+        }
+        """
+        let (response, _) = try await runProgram(source)
+        #expect(response.status == "OK")
+    }
+
+    @Test("AnalyzedProgram exposes the user-action registry")
+    func registryExposed() async throws {
+        let source = """
+        (DoubleValue: Action takes <number>) {
+            Return an <OK: status> with { doubled: 0 }.
+        }
+        (Halve: Action) {
+            Return an <OK: status> with { halved: 0 }.
+        }
+        (Application-Start: Demo) {
+            Return an <OK: status> for the <startup>.
+        }
+        """
+        let result = Compiler().compile(source)
+        let registry = result.analyzedProgram.userActions
+        #expect(registry.allNames.sorted() == ["DoubleValue", "Halve"])
+        #expect(registry.info(for: "DoubleValue")?.takesField == "number")
+        #expect(registry.info(forCallVerb: "Application.DoubleValue")?.name == "DoubleValue")
+        #expect(registry.info(forCallVerb: "Application.Missing") == nil)
+    }
+}


### PR DESCRIPTION
Closes #224. Implements [ARO-0081](https://git.ausdertechnik.de/arolang/aro/-/blob/main/Proposals/ARO-0081-user-defined-actions.md).

## Summary

A feature set whose business activity is exactly `Action` is now a **user-defined action** — callable application-wide as `Application.<Name>` with the same call-site syntax as plugin actions. This gives ARO a third callable surface, alongside built-ins and plugins, that lives entirely in `.aro` source.

```aro
(DoubleValue: Action takes <number>) {
    Extract the <n> from the <input: number>.
    Compute the <doubled> from <n> * 2.
    Return an <OK: status> with { doubled: <doubled> }.
}

(Application-Start: Demo) {
    (* Sugar form — works because the action declared `takes <number>` *)
    Application.DoubleValue the <r> from 5.
    Extract the <ten> from the <r: doubled>.

    (* Object form — always works *)
    Application.DoubleValue the <s> with { number: 7 }.
    Extract the <fourteen> from the <s: doubled>.

    Return an <OK: status> for the <startup>.
}
```

## What Changed

| Area | Change |
|------|--------|
| **AROParser** | `FeatureSet` gains `userActionTakesField` / `userActionTakesType` for the optional `Action takes <field[: Type]>` clause. `Parser.splitUserActionHeader` post-processes the activity slot. |
| **AROParser/UserActionRegistry.swift** *(new)* | `UserActionInfo`, `UserActionRegistry`, and the framework-variable name set. |
| **AROParser/UserActionAnalyzer.swift** *(new)* | Builds the registry and emits compile-time diagnostics for duplicate names, unknown `Application.<Name>` calls, `from <value>` against actions without `takes`, and framework-variable access inside Action bodies. |
| **AROParser/SemanticAnalyzer** | Runs the new analyzer; exposes `userActions` on `AnalyzedProgram`. |
| **ARORuntime/Actions/UserDefinedActionHost.swift** *(new)* | Registers `Application.<Name>` as a dynamic verb. The handler reads transients **locally** (parent-walk would leak the outer call's input into nested calls), synthesises `<input>` from the sugar field, spawns a fresh child context, runs the body via `FeatureSetExecutor`, and flattens the response. |
| **ARORuntime/Core/ExecutionEngine** | Constructs the host and registers every user-defined action before the entry point runs. |
| **Examples/UserDefinedActions** | Runnable demo (sugar, object, composed calls). |

## Tests

- **`Tests/AROParserTests/UserActionTests.swift`** *(15 tests)*: `takes` syntax, header splitting, registry construction, duplicate-name / unknown-call / sugar-without-takes / framework-variable diagnostics.
- **`Tests/AROuntimeTests/UserDefinedActionTests.swift`** *(4 tests)*: end-to-end sugar form, object form, composed calls, registry exposure.
- Full suite: **1720 tests, 0 failures**.

## Docs

- **TheLanguageGuide Chapter 6** grows §6.4 "User-Defined Actions" with takes/sugar/composition coverage; later sections renumbered.
- **ARO-0081 proposal** promoted from Draft to Accepted, with implementation notes and an updated Worked Example reflecting the shipped output shape.
- **Wiki** gains a new "User-Defined Actions" page (`Guide-User-Defined-Actions.md`) with a sidebar entry — pushed to `arolang/aro.wiki`.
- **CLAUDE.md** picks up the new example directory and proposal entry.

## Behaviour Notes

- **Output shape**: when the body uses `Return an <OK: status> with <variable>` and the variable resolves to a primitive (Int / Double / Bool / String), the value lands under the `value` key (existing Return semantics, unchanged). Use `with { name: <variable> }` whenever you want a specific field name. The proposal's Worked Example was updated to use the object-literal form.
- **Body restrictions**: `<request>`, `<response>`, `<event>`, `<pathParameters>`, `<queryParameters>` are compile errors inside an Action body — actions are synchronous transformations with no event/request context.
- **Discovery**: every `.aro` file in the application directory is already scanned at load time; any feature set whose activity is `Action` is automatically registered with `ActionRegistry` before `Application-Start` runs. No imports, no manifests.

## Test plan

- [ ] `swift test` — should report **1720 passing tests**.
- [ ] `aro run ./Examples/UserDefinedActions` should print `10 / 14 / 14` on three separate lines.
- [ ] Compile a program with two `(Foo: Action) { ... }` declarations — `aro check` should report a duplicate-action error citing both line numbers.
- [ ] Compile a program calling `Application.Missing` — `aro check` should list the known actions in the diagnostic hint.
- [ ] Compile an Action body containing `Extract the <body> from the <request: body>.` — should report a framework-variable error.
