### PR TITLE
feat(lsp,mcp): dynamic plugin actions/qualifiers via AROCatalog (#225)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ test:
       Cflags: -I${includedir}
       PKGCONFIG
   script:
-    - swift test --parallel --num-workers 2
+    - swift test
   tags:
     - spencer
 

--- a/Book/TheLanguageGuide/Chapter26-Plugins.md
+++ b/Book/TheLanguageGuide/Chapter26-Plugins.md
@@ -1055,11 +1055,20 @@ do {
 When a plugin registers actions, the registry tracks which plugin each action belongs to:
 
 ```swift
-// Actions registered with pluginName are tracked for bulk removal
+// Actions registered with pluginName are tracked for bulk removal.
+// Pass `metadata:` so editor completion and the MCP `aro_actions` tool can
+// surface the verb's role, prepositions, and description.
 await ActionRegistry.shared.registerDynamic(
     verb: "parse-csv",
     handler: myHandler,
-    pluginName: "csv-processor"
+    pluginName: "csv-processor",
+    metadata: ActionRegistry.PluginActionMetadata(
+        role: .own,
+        prepositions: ["from", "with"],
+        description: "Parse CSV input into a list of rows.",
+        handle: "CSV",
+        since: "1.0.0"
+    )
 )
 
 // Remove all verbs registered by this plugin at once
@@ -1070,7 +1079,60 @@ Actions registered without a `pluginName` are not tracked and survive `unregiste
 
 ---
 
-## 26.14 Example Plugins
+## 26.14 Tooling Discovery (LSP and MCP)
+
+Both the ARO Language Server (`aro lsp`) and the ARO MCP server (`aro mcp`) consult the live runtime registries — `ActionRegistry` and `QualifierRegistry` — through a shared `AROCatalog` service. This means **plugin-supplied actions and qualifiers show up in editors and AI tools without any extra configuration** as long as they are declared in `plugin.yaml` or returned from `aro_plugin_info()`.
+
+### How Discovery Works
+
+When the LSP starts, it captures the workspace root from the LSP `initialize` request (`rootUri` and `workspaceFolders`). On `initialized`, it walks `<workspace>/Plugins/` and registers everything found into the runtime registries — the same code path `aro run` uses. Subsequent completion, hover, and diagnostics queries see plugin verbs as first-class citizens.
+
+For MCP tools, plugin loading is opt-in: pass `directory: <workspace>` to `aro_actions` or `aro_qualifiers` and the server will load that workspace's plugins before answering. This keeps the safe default ("just describe the language") for prompts that don't need plugins, while letting workspace-aware queries see the full picture.
+
+### Declaring Metadata
+
+The richer the metadata in `plugin.yaml` or `aro_plugin_info()`, the better the editor experience:
+
+```yaml
+# plugin.yaml
+name: plugin-rust-csv
+version: 1.0.0
+handle: CSV         # PascalCase — actions appear as CSV.ParseCsv
+
+provides:
+  - type: rust-plugin
+    path: src/
+    actions:
+      - name: ParseCsv
+        verbs: [parse-csv, parsecsv]
+        role: own                        # request | own | response | export | server
+        prepositions: [from, with]
+        description: "Parse CSV input into a list of rows."
+        since: "1.0.0"
+```
+
+Hover, completion `detail`, and `aro_actions` output all read from these fields. When `role` is omitted the catalog falls back to `own`; when `description` is omitted plugin verbs still appear in completion lists, just without a one-liner.
+
+### Verifying What the Tooling Sees
+
+Quickest way to confirm a plugin is visible to tooling:
+
+```bash
+# Built-ins only
+aro mcp call aro_actions
+
+# Built-ins + plugins from this workspace
+aro mcp call aro_actions --directory $(pwd)
+
+# Same for qualifiers
+aro mcp call aro_qualifiers --directory $(pwd)
+```
+
+In the LSP, type `<` to trigger completion and look for your plugin's verbs. Hovering on a plugin verb shows the `_Provided by plugin **<name>**_` line directly under the role description.
+
+---
+
+## 26.15 Example Plugins
 
 The ARO team maintains several reference plugins:
 

--- a/Book/ThePluginGuide/AppendixA-ManifestReference.md
+++ b/Book/ThePluginGuide/AppendixA-ManifestReference.md
@@ -219,11 +219,14 @@ actions:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Action identifier |
-| `description` | No | Human-readable description |
-| `role` | No | Semantic role: `request`, `own`, `response`, `export` |
+| `description` | No | Human-readable description (shown in editor hover and `aro_actions` MCP output) |
+| `role` | No | Semantic role: `request`, `own`, `response`, `export`, `server` |
 | `verbs` | No | Verbs that trigger this action (enables `<Hash>` syntax) |
 | `prepositions` | No | Valid prepositions for this action |
+| `since` | No | Version when the action was introduced (informational, surfaced in tooling) |
 | `arguments` | No | Argument schema with types and defaults |
+
+The `description`, `role`, `prepositions`, and `since` fields are also consumed by the LSP and the MCP `aro_actions` / `aro_qualifiers` tools — the richer the manifest, the better the editor experience for downstream users.
 
 **Roles:**
 - `request`: External → Internal (Extract, Retrieve, Fetch)

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -381,8 +381,14 @@ Each Feature Set has its own symbol table:
 - Type checking
 - Advanced conditional branching
 
+### Recently Landed
+- **Dynamic plugin actions/qualifiers in LSP & MCP** (Issue #225) — both layers
+  consult the live `ActionRegistry` / `QualifierRegistry` through the shared
+  `AROCatalog` service. The LSP loads plugins from the workspace's `Plugins/`
+  folder on `initialized`; the MCP `aro_actions` and `aro_qualifiers` tools
+  accept an optional `directory:` argument to discover plugins per workspace.
+
 ### Planned
-- LSP server
 - IDE integration
 - Additional built-in actions
 

--- a/Package.swift
+++ b/Package.swift
@@ -236,6 +236,7 @@ let package = Package(
                 name: "AROLSP",
                 dependencies: [
                     "AROParser",
+                    "ARORuntime",
                 ] + lspTargetDependencies,
                 path: "Sources/AROLSP"
             ),

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Log <list: reverse> to the <console>.
 
 Write plugins in Swift, Rust, C, or Python. Qualifiers work in both interpreter and compiled binary modes.
 
+Plugin actions and qualifiers are also visible to editor tooling — the LSP loads plugins from `<workspace>/Plugins/` on `initialized`, and the MCP server's `aro_actions` / `aro_qualifiers` tools accept a `directory:` argument to surface workspace-specific plugins.
+
 ### Happy Path Philosophy
 
 Write only the success case. Errors are reported automatically in business terms. When a user cannot be retrieved, the message says exactly that.

--- a/Sources/AROLSP/AROLanguageServer.swift
+++ b/Sources/AROLSP/AROLanguageServer.swift
@@ -6,6 +6,7 @@
 #if !os(Windows)
 import Foundation
 import AROParser
+import ARORuntime
 import LanguageServerProtocol
 #if canImport(Darwin)
 import Darwin
@@ -35,6 +36,28 @@ public final class AROLanguageServer: Sendable {
     private let inlayHintHandler: InlayHintHandler
 
     private let debugMode: Bool
+
+    /// Workspace folders captured during `initialize`. Used by the catalog to
+    /// load plugins from `<workspace>/Plugins/` so plugin-supplied actions and
+    /// qualifiers show up in completion/hover.
+    private let workspaceState = WorkspaceState()
+
+    /// Thread-safe workspace tracking. The LSP class is `final class Sendable`,
+    /// so mutation goes through this serialised box.
+    private final class WorkspaceState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var roots: [URL] = []
+
+        func setRoots(_ urls: [URL]) {
+            lock.lock(); defer { lock.unlock() }
+            roots = urls
+        }
+
+        var allRoots: [URL] {
+            lock.lock(); defer { lock.unlock() }
+            return roots
+        }
+    }
 
     // MARK: - Initialization
 
@@ -204,7 +227,13 @@ public final class AROLanguageServer: Sendable {
         case "initialize":
             result = handleInitializeSync(params: params)
 
-        case "initialized", "textDocument/didOpen", "textDocument/didChange",
+        case "initialized":
+            // Client is ready; load workspace plugins now so subsequent
+            // completion/hover sees plugin-provided actions and qualifiers.
+            loadWorkspacePluginsAsync()
+            return nil
+
+        case "textDocument/didOpen", "textDocument/didChange",
              "textDocument/didClose", "textDocument/didSave", "$/cancelRequest":
             // Notifications - handle but don't respond
             handleNotificationSync(method: method, params: params)
@@ -280,6 +309,7 @@ public final class AROLanguageServer: Sendable {
 
     private func handleInitializeSync(params: Any?) -> [String: Any] {
         log("Initialize request received")
+        captureWorkspaceRoots(from: params)
         return [
             "capabilities": capabilitiesDict,
             "serverInfo": [
@@ -287,6 +317,63 @@ public final class AROLanguageServer: Sendable {
                 "version": "1.3.0"
             ]
         ]
+    }
+
+    /// Read `rootUri` and `workspaceFolders[].uri` from the LSP `initialize`
+    /// params and stash them. Used later to discover `<workspace>/Plugins/`.
+    private func captureWorkspaceRoots(from params: Any?) {
+        var roots: [URL] = []
+        if let dict = params as? [String: Any] {
+            if let rootUri = dict["rootUri"] as? String, let url = uriToURL(rootUri) {
+                roots.append(url)
+            } else if let rootPath = dict["rootPath"] as? String {
+                roots.append(URL(fileURLWithPath: rootPath))
+            }
+            if let folders = dict["workspaceFolders"] as? [[String: Any]] {
+                for folder in folders {
+                    if let uri = folder["uri"] as? String, let url = uriToURL(uri) {
+                        roots.append(url)
+                    }
+                }
+            }
+        }
+        // Deduplicate while preserving order
+        var seen: Set<URL> = []
+        let unique = roots.filter { seen.insert($0.standardizedFileURL).inserted }
+        workspaceState.setRoots(unique)
+        if !unique.isEmpty {
+            log("Workspace roots: \(unique.map { $0.path })")
+        }
+    }
+
+    /// Decode an LSP `file://` URI to a `URL`, accepting both the canonical
+    /// `file:///path` form and the bare path form some clients send.
+    private func uriToURL(_ uri: String) -> URL? {
+        if uri.hasPrefix("file://") {
+            return URL(string: uri)
+        }
+        if uri.hasPrefix("/") {
+            return URL(fileURLWithPath: uri)
+        }
+        return nil
+    }
+
+    /// Load plugins from each workspace `Plugins/` directory into the shared
+    /// AROCatalog so completion/hover sees plugin-provided actions and qualifiers.
+    /// Runs off the calling thread so `initialized` can return immediately.
+    private func loadWorkspacePluginsAsync() {
+        let roots = workspaceState.allRoots
+        guard !roots.isEmpty else { return }
+        let debug = self.debugMode
+
+        Task.detached {
+            for root in roots {
+                let loaded = await AROCatalog.shared.loadPluginsFromWorkspace(root)
+                if loaded && debug {
+                    FileHandle.standardError.write(Data("[aro-lsp] Loaded plugins from \(root.path)/Plugins\n".utf8))
+                }
+            }
+        }
     }
 
     private func handleNotificationSync(method: String, params: Any?) {
@@ -754,7 +841,9 @@ public final class AROLanguageServer: Sendable {
             result = await handleInitialize(params: params)
 
         case "initialized":
-            // Notification, no response needed
+            // Client is ready; load workspace plugins now so subsequent
+            // completion/hover sees plugin-provided actions and qualifiers.
+            loadWorkspacePluginsAsync()
             return nil
 
         case "shutdown":
@@ -849,6 +938,7 @@ public final class AROLanguageServer: Sendable {
 
     private func handleInitialize(params: Any?) async -> [String: Any] {
         log("Initialize request received")
+        captureWorkspaceRoots(from: params)
         return [
             "capabilities": capabilitiesDict,
             "serverInfo": [

--- a/Sources/AROLSP/Handlers/CompletionHandler.swift
+++ b/Sources/AROLSP/Handlers/CompletionHandler.swift
@@ -6,6 +6,7 @@
 #if !os(Windows)
 import Foundation
 import AROParser
+import ARORuntime
 import LanguageServerProtocol
 
 /// Handles textDocument/completion requests
@@ -56,98 +57,28 @@ public struct CompletionHandler: Sendable {
 
     // MARK: - Action Completions
 
+    /// Build action completion items from the AROCatalog snapshot.
+    /// The catalog merges built-ins with plugin-supplied actions, so any plugin
+    /// loaded by the LSP at workspace init shows up automatically.
     private func actionCompletions() -> [[String: Any]] {
-        let actions: [(verb: String, role: String, detail: String)] = [
-            // REQUEST actions
-            ("Extract", "REQUEST", "Extract data from external source"),
-            ("Parse", "REQUEST", "Parse structured data"),
-            ("Retrieve", "REQUEST", "Retrieve from data store"),
-            ("Fetch", "REQUEST", "Fetch from remote source"),
-            ("Receive", "REQUEST", "Receive data from socket or event stream"),
-            ("Accept", "REQUEST", "Accept input"),
-            ("Read", "REQUEST", "Read file contents"),
-            ("Request", "REQUEST", "Make an HTTP request"),
-            ("List", "REQUEST", "List directory contents"),
-            ("Stat", "REQUEST", "Get file metadata"),
-            ("Exists", "REQUEST", "Check if file exists"),
-            ("Prompt", "REQUEST", "Prompt user for terminal input"),
-            ("Select", "REQUEST", "Present a terminal selection menu"),
-
-            // OWN actions
-            ("Create", "OWN", "Create new data"),
-            ("Compute", "OWN", "Compute derived value"),
-            ("Validate", "OWN", "Validate data"),
-            ("Compare", "OWN", "Compare values"),
-            ("Transform", "OWN", "Transform data structure"),
-            ("Update", "OWN", "Update or modify a value"),
-            ("Sort", "OWN", "Sort a collection"),
-            ("Set", "OWN", "Set a value"),
-            ("Merge", "OWN", "Merge data"),
-            ("Delete", "OWN", "Delete or remove data"),
-            ("Filter", "OWN", "Filter collection"),
-            ("Match", "OWN", "Match pattern"),
-            ("Split", "OWN", "Split string by delimiter or regex"),
-            ("Join", "OWN", "Join collection elements into a string"),
-            ("Map", "OWN", "Transform each element of a collection"),
-            ("Reduce", "OWN", "Reduce a collection to a single value"),
-            ("Group", "OWN", "Group collection by field value"),
-            ("Copy", "OWN", "Copy file"),
-            ("Move", "OWN", "Move file"),
-            ("Append", "OWN", "Append to file or collection"),
-            ("Execute", "OWN", "Execute a shell command"),
-            ("Call", "OWN", "Call an external service or plugin action"),
-            ("ParseHtml", "OWN", "Parse HTML into structured data"),
-            ("ParseLinkHeader", "OWN", "Parse Link header for pagination"),
-            ("Accept", "OWN", "Accept a state transition"),
-            ("Clear", "OWN", "Clear the terminal screen"),
-
-            // RESPONSE actions
-            ("Return", "RESPONSE", "Return result"),
-            ("Throw", "RESPONSE", "Throw error"),
-            ("Broadcast", "RESPONSE", "Broadcast to all socket clients"),
-
-            // EXPORT actions
-            ("Send", "EXPORT", "Send to external system"),
-            ("Log", "EXPORT", "Log message"),
-            ("Store", "EXPORT", "Store to data store"),
-            ("Write", "EXPORT", "Write to file"),
-            ("Emit", "EXPORT", "Emit event"),
-            ("Publish", "EXPORT", "Publish symbol globally"),
-            ("Notify", "EXPORT", "Notify a recipient with a message"),
-
-            // EXPORT/OWN actions
-            ("Stream", "EXPORT", "Stream data incrementally"),
-            ("Render", "OWN", "Render a Mustache-style template"),
-
-            // SERVER actions
-            ("Start", "SERVER", "Start a service"),
-            ("Stop", "SERVER", "Stop a service"),
-            ("Keepalive", "SERVER", "Keep application running"),
-            ("WaitForEvents", "SERVER", "Suspend until events are processed"),
-            ("Schedule", "SERVER", "Schedule a recurring action"),
-            ("Sleep", "SERVER", "Pause execution for a duration"),
-            ("Listen", "SERVER", "Listen on a socket port"),
-            ("Connect", "SERVER", "Connect to a socket server"),
-            ("Close", "SERVER", "Close a connection"),
-            ("Make", "SERVER", "Create a directory"),
-            ("Watch", "SERVER", "Watch for file system changes"),
-            ("Configure", "SERVER", "Configure a service"),
-
-            // TEST actions
-            ("Given", "TEST", "Test setup"),
-            ("When", "TEST", "Test action"),
-            ("Then", "TEST", "Test assertion"),
-            ("Assert", "TEST", "Assert condition"),
-        ]
-
-        return actions.map { action in
-            [
-                "label": action.verb,
+        let entries = AROCatalog.actionsSnapshot()
+        return entries.map { entry in
+            let detail = "[\(entry.role.rawValue.uppercased())] \(entry.description ?? "")"
+            var item: [String: Any] = [
+                "label": entry.verb,
                 "kind": 3,  // Function
-                "detail": "[\(action.role)] \(action.detail)",
-                "insertText": "\(action.verb)>",
+                "detail": detail,
+                "insertText": "\(entry.verb)>",
                 "insertTextFormat": 1  // PlainText
             ]
+            // Tag plugin-supplied actions so users see where the verb came from.
+            if case .plugin(let name, _) = entry.origin {
+                item["documentation"] = [
+                    "kind": "markdown",
+                    "value": "From plugin **\(name)**.\n\n\(entry.description ?? "")"
+                ]
+            }
+            return item
         }
     }
 
@@ -175,45 +106,58 @@ public struct CompletionHandler: Sendable {
 
     // MARK: - Qualifier Completions
 
+    /// Build qualifier completion items from the AROCatalog snapshot.
+    /// Built-in qualifiers appear bare (`uppercase`); plugin qualifiers appear
+    /// twice — once bare (`reverse`) and once namespaced (`collections.reverse`).
     private func qualifierCompletions() -> [[String: Any]] {
-        let qualifiers = [
-            ("status", "Return status code"),
-            ("body", "Request/response body"),
-            ("id", "Identifier"),
-            ("data", "Data payload"),
-            ("message", "Message content"),
-            ("error", "Error information"),
-            ("result", "Operation result"),
-            ("config", "Configuration"),
-            // List element specifiers (ARO-0038)
-            ("first", "First element of list"),
-            ("last", "Last element of list"),
+        var items: [[String: Any]] = []
+
+        for entry in AROCatalog.qualifiersSnapshot() {
+            let originLabel: String = {
+                if case .plugin(let name, _) = entry.origin { return " (plugin: \(name))" }
+                return ""
+            }()
+            let detail = (entry.description ?? "qualifier") + originLabel
+
+            // Bare form (e.g. "uppercase" or "reverse")
+            items.append([
+                "label": entry.qualifier,
+                "kind": 10,  // Property
+                "detail": detail,
+                "insertText": " \(entry.qualifier)>",
+                "insertTextFormat": 1
+            ])
+
+            // Namespaced form for plugin qualifiers (e.g. "collections.reverse")
+            if !entry.namespace.isEmpty {
+                items.append([
+                    "label": entry.fullName,
+                    "kind": 10,
+                    "detail": detail,
+                    "insertText": " \(entry.fullName)>",
+                    "insertTextFormat": 1
+                ])
+            }
+        }
+
+        // List element specifiers (ARO-0038) — these aren't true qualifiers in
+        // the registry but show up after `:` in completion contexts.
+        let specifiers: [(String, String)] = [
             ("0", "Last element (reverse index)"),
             ("1", "Second-to-last element"),
             ("2", "Third-to-last element"),
-            // Compute built-in operations (qualifier-as-name)
-            ("length", "String or collection length"),
-            ("count", "Element count"),
-            ("uppercase", "Convert to uppercase"),
-            ("lowercase", "Convert to lowercase"),
-            ("hash", "Hash value"),
-            // Terminal input
-            ("hidden", "Mask input (password entry)"),
-            // ParseHtml specifiers
-            ("markdown", "Convert HTML to Markdown"),
-            ("links", "Extract all hyperlinks"),
-            ("title", "Extract page title"),
         ]
-
-        return qualifiers.map { qualifier in
-            [
-                "label": qualifier.0,
-                "kind": 10,  // Property
-                "detail": qualifier.1,
-                "insertText": " \(qualifier.0)>",
+        for (label, detail) in specifiers {
+            items.append([
+                "label": label,
+                "kind": 10,
+                "detail": detail,
+                "insertText": " \(label)>",
                 "insertTextFormat": 1
-            ]
+            ])
         }
+
+        return items
     }
 
     // MARK: - Member Completions

--- a/Sources/AROLSP/Handlers/HoverHandler.swift
+++ b/Sources/AROLSP/Handlers/HoverHandler.swift
@@ -6,6 +6,7 @@
 #if !os(Windows)
 import Foundation
 import AROParser
+import ARORuntime
 import LanguageServerProtocol
 
 /// Handles textDocument/hover requests
@@ -180,18 +181,32 @@ public struct HoverHandler: Sendable {
 
         content += "**Semantic Role**: \(action.semanticRole.rawValue)\n\n"
 
-        // Add description based on semantic role
-        switch action.semanticRole {
-        case .request:
-            content += "*Extracts or retrieves data from external sources*\n\n"
-        case .own:
-            content += "*Processes or transforms data internally*\n\n"
-        case .response:
-            content += "*Returns data or produces output*\n\n"
-        case .export:
-            content += "*Exports data or makes it globally available*\n\n"
-        case .server:
-            content += "*Manages server or service infrastructure*\n\n"
+        // Catalog lookup — surfaces both built-in descriptions and plugin
+        // metadata (description, source plugin name) using the same source of
+        // truth as completion. Match case-insensitively against the verb.
+        let catalogEntry = AROCatalog.actionsSnapshot().first {
+            $0.verb.lowercased() == action.verb.lowercased()
+        }
+        if let entry = catalogEntry, let description = entry.description {
+            content += "\(description)\n\n"
+        } else {
+            // Fallback to the role-based blurb when nothing else is known.
+            switch action.semanticRole {
+            case .request:
+                content += "*Extracts or retrieves data from external sources*\n\n"
+            case .own:
+                content += "*Processes or transforms data internally*\n\n"
+            case .response:
+                content += "*Returns data or produces output*\n\n"
+            case .export:
+                content += "*Exports data or makes it globally available*\n\n"
+            case .server:
+                content += "*Manages server or service infrastructure*\n\n"
+            }
+        }
+        if let entry = catalogEntry, case .plugin(let name, let handle) = entry.origin {
+            let handleText = handle.map { " (handle: \($0))" } ?? ""
+            content += "_Provided by plugin **\(name)**\(handleText)._\n\n"
         }
 
         // Show context

--- a/Sources/ARORuntime/Actions/ActionRegistry.swift
+++ b/Sources/ARORuntime/Actions/ActionRegistry.swift
@@ -92,6 +92,10 @@ public actor ActionRegistry {
     /// Dynamic action handlers for plugin-provided actions
     private var dynamicHandlers: [String: DynamicActionHandler] = [:]
 
+    /// Metadata for dynamic plugin actions, keyed by normalised verb.
+    /// Populated when a plugin supplies it via `registerDynamic(verb:handler:pluginName:metadata:)`.
+    private var dynamicMetadata: [String: PluginActionMetadata] = [:]
+
     /// Maps plugin name → normalised verb keys it registered (for bulk unregister)
     private var pluginVerbs: [String: Set<String>] = [:]
 
@@ -104,6 +108,35 @@ public actor ActionRegistry {
         ObjectDescriptor,
         ExecutionContext
     ) async throws -> any Sendable
+
+    /// Rich metadata for a plugin-provided action.
+    /// Carries the same shape as a built-in `BuiltInActionInfo` plus plugin origin.
+    public struct PluginActionMetadata: Sendable {
+        /// Semantic role of the action
+        public let role: ActionRole
+        /// Valid prepositions (e.g. ["from", "with"])
+        public let prepositions: [String]
+        /// Human-readable description
+        public let description: String?
+        /// PascalCase namespace handle (from `handle:` in plugin.yaml)
+        public let handle: String?
+        /// Version when this action was introduced
+        public let since: String?
+
+        public init(
+            role: ActionRole = .own,
+            prepositions: [String] = [],
+            description: String? = nil,
+            handle: String? = nil,
+            since: String? = nil
+        ) {
+            self.role = role
+            self.prepositions = prepositions
+            self.description = description
+            self.handle = handle
+            self.since = since
+        }
+    }
 
     /// Normalize action name by removing hyphens and lowercasing.
     /// Results are cached so repeated lookups of the same raw name are O(1).
@@ -119,13 +152,20 @@ public actor ActionRegistry {
     ///   - verb: The action verb
     ///   - handler: The handler function
     ///   - pluginName: Optional plugin name for bulk unregistration via `unregisterPlugin(_:)`
+    ///   - metadata: Optional rich metadata (role, prepositions, description, …) used by
+    ///     LSP/MCP completion and discovery layers. When omitted the action is still
+    ///     registered but appears with default metadata.
     public func registerDynamic(
         verb: String,
         handler: @escaping DynamicActionHandler,
-        pluginName: String? = nil
+        pluginName: String? = nil,
+        metadata: PluginActionMetadata? = nil
     ) {
         let key = normalizeActionName(verb)
         dynamicHandlers[key] = handler
+        if let metadata = metadata {
+            dynamicMetadata[key] = metadata
+        }
         if let name = pluginName {
             pluginVerbs[name, default: []].insert(key)
         }
@@ -137,6 +177,7 @@ public actor ActionRegistry {
         guard let verbs = pluginVerbs.removeValue(forKey: pluginName) else { return }
         for verb in verbs {
             dynamicHandlers.removeValue(forKey: verb)
+            dynamicMetadata.removeValue(forKey: verb)
         }
     }
 
@@ -160,11 +201,16 @@ public actor ActionRegistry {
         return actionType.init()
     }
 
-    /// Check if a verb is registered
+    /// Check if a verb is registered.
+    ///
+    /// Returns true for both built-in actions and dynamically-registered plugin
+    /// actions. The plugin lookup uses the same normalisation
+    /// (`replacingOccurrences(of: "-", with: "")` + lowercase) as `dynamicHandler(for:)`.
     /// - Parameter verb: The verb to check
-    /// - Returns: true if the verb has a registered implementation
+    /// - Returns: true if a built-in or dynamic plugin handler exists for this verb
     public func isRegistered(_ verb: String) -> Bool {
-        return actions[verb.lowercased()] != nil
+        if actions[verb.lowercased()] != nil { return true }
+        return dynamicHandlers[normalizeActionName(verb)] != nil
     }
 
     /// Get all registered verbs
@@ -223,6 +269,15 @@ public actor ActionRegistry {
         public let verb: String
         /// Name of the plugin that registered this verb (nil for anonymous)
         public let pluginName: String?
+        /// Optional rich metadata (role, prepositions, description, handle, since).
+        /// `nil` when the plugin registered without supplying metadata.
+        public let metadata: PluginActionMetadata?
+
+        public init(verb: String, pluginName: String?, metadata: PluginActionMetadata? = nil) {
+            self.verb = verb
+            self.pluginName = pluginName
+            self.metadata = metadata
+        }
     }
 
     /// Returns one entry per registered dynamic (plugin) verb.
@@ -237,7 +292,11 @@ public actor ActionRegistry {
         }
 
         return dynamicHandlers.keys.sorted().map { verb in
-            PluginActionInfo(verb: verb, pluginName: verbToPlugin[verb])
+            PluginActionInfo(
+                verb: verb,
+                pluginName: verbToPlugin[verb],
+                metadata: dynamicMetadata[verb]
+            )
         }
     }
 }

--- a/Sources/ARORuntime/Actions/ActionRegistry.swift
+++ b/Sources/ARORuntime/Actions/ActionRegistry.swift
@@ -37,6 +37,14 @@ public actor ActionRegistry {
     private init() {
         // Initialize with built-in actions (must be done in init for actor isolation)
         self.actions = Self.createBuiltInActions()
+        // Bootstrap the nonisolated read mirror so sync callers see built-ins
+        // before any async caller has had a chance to mutate the registry.
+        Self.publishMirror(
+            actions: actions,
+            dynamicHandlers: [:],
+            dynamicMetadata: [:],
+            pluginVerbs: [:]
+        )
     }
 
     // MARK: - Registration
@@ -81,12 +89,14 @@ public actor ActionRegistry {
         for verb in A.verbs {
             actions[verb.lowercased()] = action
         }
+        refreshMirror()
     }
 
     /// Unregister an action by verb
     /// - Parameter verb: The verb to unregister
     public func unregister(verb: String) {
         actions.removeValue(forKey: verb.lowercased())
+        refreshMirror()
     }
 
     /// Dynamic action handlers for plugin-provided actions
@@ -169,6 +179,7 @@ public actor ActionRegistry {
         if let name = pluginName {
             pluginVerbs[name, default: []].insert(key)
         }
+        refreshMirror()
     }
 
     /// Unregister all dynamic actions registered by a specific plugin.
@@ -179,6 +190,7 @@ public actor ActionRegistry {
             dynamicHandlers.removeValue(forKey: verb)
             dynamicMetadata.removeValue(forKey: verb)
         }
+        refreshMirror()
     }
 
     /// Get a dynamic action handler
@@ -245,22 +257,7 @@ public actor ActionRegistry {
     /// Returns one `BuiltInActionInfo` per unique built-in action type, deduplicated
     /// so that actions with multiple verbs appear only once.
     public var allBuiltInActionInfos: [BuiltInActionInfo] {
-        var seen: Set<ObjectIdentifier> = []
-        var result: [BuiltInActionInfo] = []
-        for actionType in actions.values {
-            let id = ObjectIdentifier(actionType)
-            guard seen.insert(id).inserted else { continue }
-            let name = String(describing: actionType)
-                .replacingOccurrences(of: "Action", with: "")
-            let preps = actionType.validPrepositions.map { $0.rawValue }.sorted()
-            result.append(BuiltInActionInfo(
-                name: name,
-                role: actionType.role,
-                verbs: actionType.verbs.sorted(),
-                prepositions: preps
-            ))
-        }
-        return result.sorted { $0.name < $1.name }
+        Self.buildBuiltInActionInfos(actions: actions)
     }
 
     /// Summary of a plugin (dynamic) action for display/documentation purposes
@@ -283,14 +280,89 @@ public actor ActionRegistry {
     /// Returns one entry per registered dynamic (plugin) verb.
     /// Each entry includes the plugin name if the verb was registered with `pluginName:`.
     public var allPluginActionInfos: [PluginActionInfo] {
-        // Build an inverted map from verb → plugin name
+        Self.buildPluginActionInfos(
+            dynamicHandlers: dynamicHandlers,
+            dynamicMetadata: dynamicMetadata,
+            pluginVerbs: pluginVerbs
+        )
+    }
+
+    // MARK: - Nonisolated Read Mirror
+    //
+    // Synchronous, lock-protected mirror of the inspection data above. Lets
+    // sync callers (LSP handlers, AROCatalog snapshots) read action metadata
+    // without going through `await`, which is what previously triggered the
+    // `Task { … }; semaphore.wait()` deadlock that starved the cooperative
+    // thread pool under `swift test --parallel`.
+    //
+    // The mirror is refreshed inside every mutating actor method, so async
+    // writers and sync readers stay consistent.
+
+    private static let _mirrorLock = NSLock()
+    nonisolated(unsafe) private static var _mirrorBuiltIns: [BuiltInActionInfo] = []
+    nonisolated(unsafe) private static var _mirrorPlugins: [PluginActionInfo] = []
+
+    /// Push the actor's current state into the read mirror.
+    /// Called from inside actor-isolated mutators.
+    private func refreshMirror() {
+        Self.publishMirror(
+            actions: actions,
+            dynamicHandlers: dynamicHandlers,
+            dynamicMetadata: dynamicMetadata,
+            pluginVerbs: pluginVerbs
+        )
+    }
+
+    private static func publishMirror(
+        actions: [String: any ActionImplementation.Type],
+        dynamicHandlers: [String: DynamicActionHandler],
+        dynamicMetadata: [String: PluginActionMetadata],
+        pluginVerbs: [String: Set<String>]
+    ) {
+        let builtIns = buildBuiltInActionInfos(actions: actions)
+        let plugins = buildPluginActionInfos(
+            dynamicHandlers: dynamicHandlers,
+            dynamicMetadata: dynamicMetadata,
+            pluginVerbs: pluginVerbs
+        )
+        _mirrorLock.lock()
+        _mirrorBuiltIns = builtIns
+        _mirrorPlugins = plugins
+        _mirrorLock.unlock()
+    }
+
+    private static func buildBuiltInActionInfos(
+        actions: [String: any ActionImplementation.Type]
+    ) -> [BuiltInActionInfo] {
+        var seen: Set<ObjectIdentifier> = []
+        var result: [BuiltInActionInfo] = []
+        for actionType in actions.values {
+            let id = ObjectIdentifier(actionType)
+            guard seen.insert(id).inserted else { continue }
+            let name = String(describing: actionType)
+                .replacingOccurrences(of: "Action", with: "")
+            let preps = actionType.validPrepositions.map { $0.rawValue }.sorted()
+            result.append(BuiltInActionInfo(
+                name: name,
+                role: actionType.role,
+                verbs: actionType.verbs.sorted(),
+                prepositions: preps
+            ))
+        }
+        return result.sorted { $0.name < $1.name }
+    }
+
+    private static func buildPluginActionInfos(
+        dynamicHandlers: [String: DynamicActionHandler],
+        dynamicMetadata: [String: PluginActionMetadata],
+        pluginVerbs: [String: Set<String>]
+    ) -> [PluginActionInfo] {
         var verbToPlugin: [String: String] = [:]
         for (plugin, verbs) in pluginVerbs {
             for verb in verbs {
                 verbToPlugin[verb] = plugin
             }
         }
-
         return dynamicHandlers.keys.sorted().map { verb in
             PluginActionInfo(
                 verb: verb,
@@ -298,6 +370,26 @@ public actor ActionRegistry {
                 metadata: dynamicMetadata[verb]
             )
         }
+    }
+
+    /// Synchronous, nonisolated snapshot of `allBuiltInActionInfos`.
+    /// Safe to call from any context including the cooperative thread pool —
+    /// reads are lock-protected, no actor hop required.
+    public nonisolated static var snapshotBuiltInActionInfos: [BuiltInActionInfo] {
+        // Force the singleton's lazy init so the mirror is populated even when
+        // a sync caller is the very first to touch the registry.
+        _ = ActionRegistry.shared
+        _mirrorLock.lock()
+        defer { _mirrorLock.unlock() }
+        return _mirrorBuiltIns
+    }
+
+    /// Synchronous, nonisolated snapshot of `allPluginActionInfos`.
+    public nonisolated static var snapshotPluginActionInfos: [PluginActionInfo] {
+        _ = ActionRegistry.shared
+        _mirrorLock.lock()
+        defer { _mirrorLock.unlock() }
+        return _mirrorPlugins
     }
 }
 

--- a/Sources/ARORuntime/Catalog/AROCatalog.swift
+++ b/Sources/ARORuntime/Catalog/AROCatalog.swift
@@ -1,0 +1,440 @@
+// ============================================================
+// AROCatalog.swift
+// ARO Runtime - Shared discovery surface for actions and qualifiers
+// (Issue #225)
+// ============================================================
+
+import Foundation
+
+// MARK: - Origin
+
+/// Where a catalog entry came from. Lets consumers filter built-ins from
+/// plugin-provided contributions and identify the source plugin.
+public enum CatalogOrigin: Sendable, Equatable {
+    case builtin
+    case plugin(name: String, handle: String?)
+}
+
+// MARK: - Action Entry
+
+/// Structured description of a single action verb. This is the type LSP and
+/// MCP consume — both built-ins and plugin actions reduce to the same shape.
+public struct CatalogActionEntry: Sendable, Equatable {
+    /// Display name (e.g. "Extract"). For plugin actions this is the action's
+    /// canonical name, not the namespaced form.
+    public let verb: String
+    /// Semantic role (request/own/response/export/server)
+    public let role: ActionRole
+    /// Valid prepositions for this action (e.g. ["from", "with"])
+    public let prepositions: [String]
+    /// Human-readable description, when known
+    public let description: String?
+    /// Origin (built-in or plugin)
+    public let origin: CatalogOrigin
+    /// Version when this action was introduced (plugin actions only)
+    public let since: String?
+
+    public init(
+        verb: String,
+        role: ActionRole,
+        prepositions: [String] = [],
+        description: String? = nil,
+        origin: CatalogOrigin = .builtin,
+        since: String? = nil
+    ) {
+        self.verb = verb
+        self.role = role
+        self.prepositions = prepositions
+        self.description = description
+        self.origin = origin
+        self.since = since
+    }
+}
+
+// MARK: - Qualifier Entry
+
+/// Structured description of a qualifier. Built-in qualifiers have an empty
+/// `namespace`; plugin qualifiers carry the handle declared in `plugin.yaml`
+/// (e.g. `collections.reverse`).
+public struct CatalogQualifierEntry: Sendable, Equatable {
+    /// Namespace (e.g. "collections"); empty string for built-ins
+    public let namespace: String
+    /// Plain qualifier name (e.g. "reverse", "uppercase")
+    public let qualifier: String
+    /// Accepted input types
+    public let inputTypes: [String]
+    /// Whether the qualifier accepts parameters via a `with` clause
+    public let acceptsParameters: Bool
+    /// Human-readable description, when known
+    public let description: String?
+    /// Origin (built-in or plugin)
+    public let origin: CatalogOrigin
+
+    public init(
+        namespace: String,
+        qualifier: String,
+        inputTypes: [String] = [],
+        acceptsParameters: Bool = false,
+        description: String? = nil,
+        origin: CatalogOrigin = .builtin
+    ) {
+        self.namespace = namespace
+        self.qualifier = qualifier
+        self.inputTypes = inputTypes
+        self.acceptsParameters = acceptsParameters
+        self.description = description
+        self.origin = origin
+    }
+
+    /// Display form: `qualifier` for built-ins, `namespace.qualifier` otherwise.
+    public var fullName: String {
+        namespace.isEmpty || namespace == "_builtin" ? qualifier : "\(namespace).\(qualifier)"
+    }
+}
+
+// MARK: - Catalog
+
+/// Single source of truth for the LSP and MCP layers when answering "what
+/// actions/qualifiers are available?"
+///
+/// Wraps `ActionRegistry` and `QualifierRegistry` so consumers don't need to
+/// reach into either, and tracks plugin loads done on behalf of editors and
+/// tools (which run outside the normal `aro run` flow).
+public actor AROCatalog {
+    /// Shared instance. Use this for the LSP server's process-wide state.
+    public static let shared = AROCatalog()
+
+    /// Plugin directories that have been loaded into the registries.
+    /// Avoids reloading the same workspace twice.
+    private var loadedWorkspaces: Set<URL> = []
+
+    public init() {}
+
+    // MARK: - Plugin Loading
+
+    /// Discover and load all plugins from `<workspaceRoot>/Plugins/` into the
+    /// shared `ActionRegistry` and `QualifierRegistry`.
+    ///
+    /// Safe to call multiple times — duplicate loads are skipped. Errors during
+    /// individual plugin loads are logged but do not throw, mirroring the
+    /// runtime's behaviour.
+    /// - Parameter workspaceRoot: The user's project directory (the parent of
+    ///   `Plugins/`, not the `Plugins/` directory itself).
+    /// - Returns: True if at least one plugin was discovered, false otherwise.
+    @discardableResult
+    public func loadPluginsFromWorkspace(_ workspaceRoot: URL) -> Bool {
+        let resolved = workspaceRoot.standardizedFileURL
+        guard !loadedWorkspaces.contains(resolved) else { return true }
+
+        let pluginsDir = resolved.appendingPathComponent("Plugins")
+        guard FileManager.default.fileExists(atPath: pluginsDir.path) else {
+            return false
+        }
+
+        do {
+            try UnifiedPluginLoader.shared.loadPlugins(from: resolved)
+            loadedWorkspaces.insert(resolved)
+            return true
+        } catch {
+            AROLogger.warning("AROCatalog: plugin load failed for \(resolved.path): \(error)", subsystem: "catalog")
+            return false
+        }
+    }
+
+    /// Returns true if the catalog has loaded the given workspace.
+    public func hasLoaded(_ workspaceRoot: URL) -> Bool {
+        loadedWorkspaces.contains(workspaceRoot.standardizedFileURL)
+    }
+
+    /// Forget all workspace tracking (useful for tests). Does NOT unload
+    /// plugins from the registries — call `UnifiedPluginLoader.shared.unloadAll()`
+    /// for that.
+    public func resetTrackingForTesting() {
+        loadedWorkspaces.removeAll()
+    }
+
+    // MARK: - Actions
+
+    /// All known actions, optionally filtered by role.
+    /// Built-ins come first, plugin actions follow, both sorted by name.
+    public func actions(role: ActionRole? = nil) async -> [CatalogActionEntry] {
+        var entries: [CatalogActionEntry] = []
+
+        // Built-ins from ActionRegistry, decorated with descriptions
+        let builtIns = await ActionRegistry.shared.allBuiltInActionInfos
+        for info in builtIns {
+            // Each unique action type may register multiple verbs. Surface every
+            // verb so completion can suggest "Retrieve" and "Fetch" separately
+            // even though they share an implementation.
+            for verb in info.verbs {
+                let entry = CatalogActionEntry(
+                    verb: Self.displayCase(verb),
+                    role: info.role,
+                    prepositions: info.prepositions,
+                    description: AROCatalogDescriptions.action(named: verb),
+                    origin: .builtin,
+                    since: nil
+                )
+                if role == nil || entry.role == role { entries.append(entry) }
+            }
+        }
+
+        // Plugin actions from ActionRegistry
+        let pluginInfos = await ActionRegistry.shared.allPluginActionInfos
+        for info in pluginInfos {
+            // Skip namespaced duplicates ("hash.hash") — keep only the plain verb
+            // since the catalog already records the handle separately.
+            if info.verb.contains(".") { continue }
+
+            let metadata = info.metadata
+            let pluginRole = metadata?.role ?? .own
+            let entry = CatalogActionEntry(
+                verb: Self.displayCase(info.verb),
+                role: pluginRole,
+                prepositions: metadata?.prepositions ?? [],
+                description: metadata?.description,
+                origin: .plugin(name: info.pluginName ?? "", handle: metadata?.handle),
+                since: metadata?.since
+            )
+            if role == nil || entry.role == role { entries.append(entry) }
+        }
+
+        return entries.sorted { $0.verb < $1.verb }
+    }
+
+    // MARK: - Qualifiers
+
+    /// All known qualifiers, optionally filtered by namespace.
+    /// `namespace == nil` returns everything; pass `""` for built-ins only.
+    public func qualifiers(namespace: String? = nil) -> [CatalogQualifierEntry] {
+        var entries: [CatalogQualifierEntry] = []
+
+        // QualifierRegistry already knows about both built-ins (registered as
+        // `_builtin.<name>`) and plugin qualifiers.
+        for reg in QualifierRegistry.shared.allRegistrations() {
+            let isBuiltIn = reg.namespace == "_builtin"
+            let entry = CatalogQualifierEntry(
+                namespace: isBuiltIn ? "" : reg.namespace,
+                qualifier: reg.qualifier,
+                inputTypes: reg.inputTypes.map { $0.rawValue }.sorted(),
+                acceptsParameters: reg.acceptsParameters,
+                description: reg.description,
+                origin: isBuiltIn ? .builtin : .plugin(name: reg.pluginName, handle: reg.namespace)
+            )
+
+            if let filter = namespace {
+                if entry.namespace == filter { entries.append(entry) }
+            } else {
+                entries.append(entry)
+            }
+        }
+
+        // Add specifier-only qualifiers (status/body/data/etc.) that are not in
+        // QualifierRegistry but are documented for completion.
+        if namespace == nil || namespace == "" {
+            for spec in AROCatalogDescriptions.specifierQualifiers {
+                entries.append(CatalogQualifierEntry(
+                    namespace: "",
+                    qualifier: spec.name,
+                    inputTypes: [],
+                    acceptsParameters: false,
+                    description: spec.description,
+                    origin: .builtin
+                ))
+            }
+        }
+
+        return entries.sorted { lhs, rhs in
+            if lhs.namespace == rhs.namespace { return lhs.qualifier < rhs.qualifier }
+            return lhs.namespace < rhs.namespace
+        }
+    }
+
+    // MARK: - Synchronous Snapshots
+    //
+    // The LSP runs request handlers off a sync, blocking read loop and can't
+    // `await` the actor. These helpers spin up a transient task and block via
+    // a semaphore so callers stuck on a sync boundary still get a snapshot.
+    // Use sparingly — async callers should prefer `actions()` / `qualifiers()`.
+
+    /// Synchronous snapshot of `actions(role:)`. Blocks the caller on a
+    /// `DispatchSemaphore` while the actor materialises the list.
+    public nonisolated static func actionsSnapshot(role: ActionRole? = nil) -> [CatalogActionEntry] {
+        let box = SnapshotBox<[CatalogActionEntry]>()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            let entries = await AROCatalog.shared.actions(role: role)
+            box.set(entries)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.get() ?? []
+    }
+
+    /// Synchronous snapshot of `qualifiers(namespace:)`.
+    /// QualifierRegistry is not actor-isolated, so this is a direct call.
+    public nonisolated static func qualifiersSnapshot(namespace: String? = nil) -> [CatalogQualifierEntry] {
+        let box = SnapshotBox<[CatalogQualifierEntry]>()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            let entries = await AROCatalog.shared.qualifiers(namespace: namespace)
+            box.set(entries)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.get() ?? []
+    }
+
+    // MARK: - Helpers
+
+    /// Capitalise the first character of a verb for display ("extract" → "Extract").
+    /// Plugin verbs are already lowercased when normalised; built-in verbs are
+    /// stored lowercased; LSP/MCP consumers expect title-case.
+    private static func displayCase(_ verb: String) -> String {
+        guard let first = verb.first else { return verb }
+        return first.uppercased() + verb.dropFirst()
+    }
+}
+
+// MARK: - Snapshot Box (sync/async bridge)
+
+/// Thread-safe holder used by `actionsSnapshot` / `qualifiersSnapshot` to
+/// hand a Sendable result back from a Task to the blocking caller.
+final class SnapshotBox<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T?
+
+    func set(_ v: T) {
+        lock.lock(); defer { lock.unlock() }
+        value = v
+    }
+
+    func get() -> T? {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+}
+
+// MARK: - Built-in Description Tables
+
+/// Static descriptions for built-in actions and "specifier" qualifiers
+/// (status/body/data/etc.) — pulled out of CompletionHandler and MCPToolProvider
+/// so the catalog is the single source of truth.
+public enum AROCatalogDescriptions {
+
+    /// Description for a built-in action verb (case-insensitive lookup).
+    public static func action(named verb: String) -> String? {
+        actionDescriptions[verb.lowercased()]
+    }
+
+    /// Specifiers that appear after `:` but aren't real qualifiers (HTTP statuses,
+    /// extraction shortcuts, ParseHtml output forms, …). Surfaced for completion.
+    public static let specifierQualifiers: [(name: String, description: String)] = [
+        ("status", "HTTP-style status qualifier (OK, Created, NotFound, …)"),
+        ("body", "Request/response body"),
+        ("id", "Identifier"),
+        ("data", "Data payload"),
+        ("message", "Message content"),
+        ("error", "Error information"),
+        ("result", "Operation result"),
+        ("config", "Configuration"),
+        ("first", "First element of a list"),
+        ("last", "Last element of a list"),
+        ("hidden", "Mask input (password entry)"),
+        ("markdown", "Convert HTML to Markdown"),
+        ("links", "Extract all hyperlinks"),
+        ("title", "Extract page title"),
+    ]
+
+    /// Descriptions for all built-in action verbs. Keys are lowercased verbs.
+    /// Migrated from the inline arrays in `CompletionHandler.actionCompletions()`
+    /// and `MCPToolProvider.executeActions()`.
+    private static let actionDescriptions: [String: String] = [
+        // REQUEST
+        "extract": "Extract data from events, requests, parameters, or path parameters",
+        "parse": "Parse structured data (JSON, HTML, XML, CSV)",
+        "parsehtml": "Parse HTML into structured data",
+        "parselinkheader": "Parse HTTP Link header for pagination",
+        "retrieve": "Retrieve from a repository (supports `where field = value` and `default`)",
+        "fetch": "Make HTTP GET requests to external services",
+        "receive": "Receive data from a socket connection or event stream",
+        "accept": "Accept input or accept a state transition",
+        "read": "Read content from a file",
+        "request": "Make an HTTP request (GET, POST, PUT, DELETE)",
+        "list": "List directory contents",
+        "stat": "Get file metadata (size, dates, permissions)",
+        "exists": "Check if a path exists",
+        "prompt": "Prompt the user for terminal input",
+        "select": "Present a terminal selection menu",
+
+        // OWN
+        "create": "Create new objects or collections",
+        "compute": "Calculate values (arithmetic, length, uppercase, lowercase, hash, …)",
+        "validate": "Validate data against rules or schemas",
+        "compare": "Compare two values; result is a boolean",
+        "transform": "Convert data between types (int/float/string/bool)",
+        "update": "Update fields on an existing object",
+        "sort": "Sort a collection by field",
+        "set": "Set a value",
+        "merge": "Merge two collections or objects",
+        "delete": "Remove data from a collection",
+        "filter": "Filter a collection by predicate",
+        "match": "Match against a pattern",
+        "split": "Split a string by delimiter or regex",
+        "join": "Join list elements into a string",
+        "map": "Transform each element of a collection",
+        "reduce": "Reduce a collection to a single value",
+        "group": "Group a collection by field value",
+        "copy": "Copy a file to a destination",
+        "move": "Move or rename a file",
+        "append": "Append to a file or collection",
+        "execute": "Execute a system shell command",
+        "call": "Call an external service or plugin action",
+        "clear": "Clear the terminal screen",
+        "render": "Render a Mustache-style template",
+
+        // RESPONSE
+        "return": "Return success with optional data",
+        "throw": "Return an error response",
+        "broadcast": "Broadcast to all connected clients",
+
+        // EXPORT
+        "send": "Send an HTTP request or message to a service/socket",
+        "log": "Write to console / logs",
+        "store": "Save to a repository (auto-generates `id`)",
+        "write": "Write content to a file",
+        "emit": "Emit a domain event to the event bus",
+        "publish": "Make a variable globally visible across feature sets",
+        "notify": "Send a notification to one or more recipients",
+        "stream": "Stream data lazily to an output or pipe",
+
+        // SERVER
+        "start": "Start a server or service (http-server, file-monitor, socket-server)",
+        "stop": "Stop a running service",
+        "keepalive": "Keep the application running to process events (blocks until SIGINT)",
+        "waitforevents": "Wait until all pending events are processed",
+        "schedule": "Schedule a repeating timer event every N seconds",
+        "sleep": "Pause execution for N seconds",
+        "listen": "Listen for incoming connections on a port",
+        "connect": "Connect to a TCP server",
+        "close": "Close a connection",
+        "make": "Create a directory",
+        "watch": "Watch for file system changes",
+        "configure": "Configure runtime settings (timeout, retry, …)",
+
+        // TEST
+        "given": "Set up test context",
+        "when": "Execute the action under test",
+        "then": "Assert expected outcomes",
+        "assert": "Make a specific assertion",
+
+        // GIT (ARO-0080)
+        "stage": "Stage files into the git index",
+        "commit": "Commit staged changes to the repository",
+        "pull": "Pull from the configured remote",
+        "push": "Push to the configured remote",
+        "clone": "Clone a remote repository",
+        "checkout": "Checkout a branch",
+        "tag": "Tag a commit",
+    ]
+}

--- a/Sources/ARORuntime/Catalog/AROCatalog.swift
+++ b/Sources/ARORuntime/Catalog/AROCatalog.swift
@@ -157,11 +157,19 @@ public actor AROCatalog {
 
     /// All known actions, optionally filtered by role.
     /// Built-ins come first, plugin actions follow, both sorted by name.
-    public func actions(role: ActionRole? = nil) async -> [CatalogActionEntry] {
+    ///
+    /// `nonisolated` so sync callers (LSP handlers, snapshot helpers) can
+    /// invoke this without spawning a Task and blocking on a semaphore — the
+    /// pattern that previously deadlocked the cooperative thread pool under
+    /// `swift test --parallel`. The underlying registries are themselves
+    /// thread-safe (`ActionRegistry` exposes a lock-protected mirror;
+    /// `QualifierRegistry` is a sync class), so we don't need actor isolation
+    /// here.
+    public nonisolated func actions(role: ActionRole? = nil) -> [CatalogActionEntry] {
         var entries: [CatalogActionEntry] = []
 
         // Built-ins from ActionRegistry, decorated with descriptions
-        let builtIns = await ActionRegistry.shared.allBuiltInActionInfos
+        let builtIns = ActionRegistry.snapshotBuiltInActionInfos
         for info in builtIns {
             // Each unique action type may register multiple verbs. Surface every
             // verb so completion can suggest "Retrieve" and "Fetch" separately
@@ -180,7 +188,7 @@ public actor AROCatalog {
         }
 
         // Plugin actions from ActionRegistry
-        let pluginInfos = await ActionRegistry.shared.allPluginActionInfos
+        let pluginInfos = ActionRegistry.snapshotPluginActionInfos
         for info in pluginInfos {
             // Skip namespaced duplicates ("hash.hash") — keep only the plain verb
             // since the catalog already records the handle separately.
@@ -206,7 +214,10 @@ public actor AROCatalog {
 
     /// All known qualifiers, optionally filtered by namespace.
     /// `namespace == nil` returns everything; pass `""` for built-ins only.
-    public func qualifiers(namespace: String? = nil) -> [CatalogQualifierEntry] {
+    ///
+    /// `nonisolated` for the same reason as `actions(role:)`: only reads from
+    /// the thread-safe `QualifierRegistry`, so no actor hop is required.
+    public nonisolated func qualifiers(namespace: String? = nil) -> [CatalogQualifierEntry] {
         var entries: [CatalogQualifierEntry] = []
 
         // QualifierRegistry already knows about both built-ins (registered as
@@ -252,37 +263,20 @@ public actor AROCatalog {
 
     // MARK: - Synchronous Snapshots
     //
-    // The LSP runs request handlers off a sync, blocking read loop and can't
-    // `await` the actor. These helpers spin up a transient task and block via
-    // a semaphore so callers stuck on a sync boundary still get a snapshot.
-    // Use sparingly — async callers should prefer `actions()` / `qualifiers()`.
+    // Direct nonisolated reads. The previous implementation spun a Task and
+    // blocked the caller on a `DispatchSemaphore` — under `swift test
+    // --parallel`, that pattern starved the cooperative thread pool and
+    // deadlocked the entire test run. Now that `actions()` / `qualifiers()`
+    // are themselves `nonisolated`, snapshots are plain function calls.
 
-    /// Synchronous snapshot of `actions(role:)`. Blocks the caller on a
-    /// `DispatchSemaphore` while the actor materialises the list.
+    /// Synchronous snapshot of `actions(role:)`.
     public nonisolated static func actionsSnapshot(role: ActionRole? = nil) -> [CatalogActionEntry] {
-        let box = SnapshotBox<[CatalogActionEntry]>()
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
-            let entries = await AROCatalog.shared.actions(role: role)
-            box.set(entries)
-            semaphore.signal()
-        }
-        semaphore.wait()
-        return box.get() ?? []
+        AROCatalog.shared.actions(role: role)
     }
 
     /// Synchronous snapshot of `qualifiers(namespace:)`.
-    /// QualifierRegistry is not actor-isolated, so this is a direct call.
     public nonisolated static func qualifiersSnapshot(namespace: String? = nil) -> [CatalogQualifierEntry] {
-        let box = SnapshotBox<[CatalogQualifierEntry]>()
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
-            let entries = await AROCatalog.shared.qualifiers(namespace: namespace)
-            box.set(entries)
-            semaphore.signal()
-        }
-        semaphore.wait()
-        return box.get() ?? []
+        AROCatalog.shared.qualifiers(namespace: namespace)
     }
 
     // MARK: - Helpers
@@ -293,25 +287,6 @@ public actor AROCatalog {
     private static func displayCase(_ verb: String) -> String {
         guard let first = verb.first else { return verb }
         return first.uppercased() + verb.dropFirst()
-    }
-}
-
-// MARK: - Snapshot Box (sync/async bridge)
-
-/// Thread-safe holder used by `actionsSnapshot` / `qualifiersSnapshot` to
-/// hand a Sendable result back from a Task to the blocking caller.
-final class SnapshotBox<T: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value: T?
-
-    func set(_ v: T) {
-        lock.lock(); defer { lock.unlock() }
-        value = v
-    }
-
-    func get() -> T? {
-        lock.lock(); defer { lock.unlock() }
-        return value
     }
 }
 

--- a/Sources/ARORuntime/MCP/MCPToolProvider.swift
+++ b/Sources/ARORuntime/MCP/MCPToolProvider.swift
@@ -87,13 +87,34 @@ public struct MCPToolProvider: Sendable {
             ),
             MCPTool(
                 name: "aro_actions",
-                description: "List all available ARO actions with their roles, verbs, and valid prepositions.",
+                description: "List all available ARO actions with their roles, verbs, and valid prepositions. Pass 'directory' to also include plugin actions discovered under that workspace's Plugins/ folder.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
                         "role": .object([
                             "type": .string("string"),
                             "description": .string("Filter by action role: request, own, response, export, server (optional)")
+                        ]),
+                        "directory": .object([
+                            "type": .string("string"),
+                            "description": .string("Workspace directory whose `Plugins/` folder should be loaded so plugin-supplied actions appear in the list (optional). When omitted, only built-ins are listed.")
+                        ])
+                    ])
+                ])
+            ),
+            MCPTool(
+                name: "aro_qualifiers",
+                description: "List all available ARO qualifiers (built-in and plugin-supplied). Pass 'directory' to load workspace plugins and surface their namespaced qualifiers.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "namespace": .object([
+                            "type": .string("string"),
+                            "description": .string("Filter to a single namespace (e.g. 'collections'). Empty string returns built-ins only. Optional.")
+                        ]),
+                        "directory": .object([
+                            "type": .string("string"),
+                            "description": .string("Workspace directory whose `Plugins/` folder should be loaded (optional).")
                         ])
                     ])
                 ])
@@ -140,7 +161,9 @@ public struct MCPToolProvider: Sendable {
         case "aro_examples":
             return executeExamples(arguments: arguments)
         case "aro_actions":
-            return executeActions(arguments: arguments)
+            return await executeActions(arguments: arguments)
+        case "aro_qualifiers":
+            return await executeQualifiers(arguments: arguments)
         case "aro_parse":
             return executeParse(arguments: arguments)
         case "aro_syntax":
@@ -532,154 +555,138 @@ public struct MCPToolProvider: Sendable {
         return MCPToolCallResult(content: [.text(output)])
     }
 
-    /// List all available actions
-    private func executeActions(arguments: JSONValue?) -> MCPToolCallResult {
+    /// List all available actions, sourced from the live `AROCatalog`.
+    /// When `directory:` is supplied, plugins from `<directory>/Plugins/` are
+    /// loaded into the shared registries first so plugin actions show up too.
+    private func executeActions(arguments: JSONValue?) async -> MCPToolCallResult {
         let roleFilter = arguments?["role"]?.stringValue?.lowercased()
+        let directory = arguments?["directory"]?.stringValue
 
-        struct ActionGroup {
-            let role: String
-            let title: String
-            let description: String
-            let actions: [(name: String, description: String, prepositions: String)]
-        }
-
-        let groups: [ActionGroup] = [
-            ActionGroup(
-                role: "request",
-                title: "REQUEST Actions (External → Internal)",
-                description: "Bring data into the feature set:",
-                actions: [
-                    ("Extract", "Get data from events, requests, parameters, path parameters", "from"),
-                    ("Retrieve", "Get data from repositories; supports `where field = value` and `default` fallback", "from"),
-                    ("Fetch", "Make HTTP GET requests to external services", "from"),
-                    ("Request", "Make HTTP requests (GET, POST, PUT, DELETE)", "from"),
-                    ("Read", "Read content from files", "from"),
-                    ("Receive", "Receive data from socket connections", "from"),
-                    ("Parse", "Parse structured data (JSON, HTML, XML, CSV)", "from"),
-                    ("ParseLinkHeader", "Parse HTTP Link header into pagination info", "from"),
-                ]
-            ),
-            ActionGroup(
-                role: "own",
-                title: "OWN Actions (Internal → Internal)",
-                description: "Transform data within the feature set:",
-                actions: [
-                    ("Compute", "Calculate values; supports arithmetic, length, uppercase, lowercase, hash, string concat (++)", "from, with"),
-                    ("Validate", "Check data against rules or schemas", "against, with"),
-                    ("Compare", "Compare two values; result is a boolean", "against"),
-                    ("Transform", "Convert data between types (int, float, string, bool)", "to, with"),
-                    ("Create", "Create new objects or collections", "with, from"),
-                    ("Update", "Update fields on an existing object", "in, with"),
-                    ("Delete", "Remove data from a collection", "from"),
-                    ("Filter", "Filter collections by predicate", "with, from"),
-                    ("Sort", "Sort collections by field", "with"),
-                    ("Split", "Split strings by delimiter or regex (`by /pattern/`)", "with, by"),
-                    ("Join", "Join list elements into a string with separator", "with"),
-                    ("Merge", "Merge two collections or objects", "with"),
-                ]
-            ),
-            ActionGroup(
-                role: "response",
-                title: "RESPONSE Actions (Internal → External)",
-                description: "Return results from the feature set:",
-                actions: [
-                    ("Return", "Return success with optional data (HTTP 200/201/etc via qualifier)", "for, with"),
-                    ("Throw", "Return an error response", "for"),
-                    ("Render", "Render a template and return the result", "from, with"),
-                ]
-            ),
-            ActionGroup(
-                role: "export",
-                title: "EXPORT Actions (Internal → External)",
-                description: "Send data outside the feature set:",
-                actions: [
-                    ("Log", "Write to console/logs", "to"),
-                    ("Store", "Save to repository (auto-generates `id`)", "in, into"),
-                    ("Write", "Write content to a file", "to"),
-                    ("Append", "Append content to a file", "to"),
-                    ("Send", "Send HTTP request or message to service/socket", "to"),
-                    ("Notify", "Send notification to target(s); dispatches NotificationSent events", "to, with"),
-                    ("Emit", "Emit a domain event to the event bus", "with"),
-                    ("Publish", "Make a variable globally visible across feature sets", "as"),
-                    ("Stream", "Stream data lazily to an output or pipe", "to, with"),
-                ]
-            ),
-            ActionGroup(
-                role: "server",
-                title: "SERVER Actions",
-                description: "Control servers, services, and timing:",
-                actions: [
-                    ("Start", "Start a server or service (http-server, file-monitor, socket-server)", "with"),
-                    ("Stop", "Stop a running service", "with"),
-                    ("Listen", "Listen for incoming connections on a port", "on"),
-                    ("Keepalive", "Keep the application running to process events (blocks until SIGINT/SIGTERM)", "for"),
-                    ("Schedule", "Schedule a repeating timer event every N seconds", "with"),
-                    ("Sleep", "Pause execution for N seconds", "for"),
-                    ("WaitForEvents", "Wait until all pending events are processed", "for"),
-                    ("Configure", "Configure runtime settings (timeout, retry, etc.)", "with"),
-                    ("Accept", "Accept a state transition for an entity (triggers StateTransition events)", "for"),
-                ]
-            ),
-        ]
-
-        var output = "# ARO Actions\n\n"
-        output += "ARO has \(groups.flatMap { $0.actions }.count)+ built-in actions organized by role.\n\n"
-
-        for group in groups {
-            if let filter = roleFilter, group.role != filter { continue }
-            output += "## \(group.title)\n"
-            output += "\(group.description)\n\n"
-            for action in group.actions {
-                output += "- **\(action.name)**: \(action.description). Prepositions: `\(action.prepositions)`\n"
-            }
-            output += "\n"
-        }
-
-        if roleFilter != nil && !groups.contains(where: { $0.role == roleFilter }) {
+        // Validate role early so we can return a friendly error.
+        let knownRoles: Set<String> = ["request", "own", "response", "export", "server"]
+        if let role = roleFilter, !knownRoles.contains(role) {
             return MCPToolCallResult(
                 content: [.text("Unknown role filter. Use: request, own, response, export, server")],
                 isError: true
             )
         }
 
-        // File system actions (always shown unless filtered to a different role)
-        if roleFilter == nil {
-            output += """
-            ## FILE Actions
-            File system operations:
+        // Optional plugin loading from the user's workspace. Errors are logged
+        // by the catalog and we continue with built-ins.
+        if let directory = directory {
+            let url = URL(fileURLWithPath: directory)
+            _ = await AROCatalog.shared.loadPluginsFromWorkspace(url)
+        }
 
-            - **List**: List directory contents. Prepositions: `from`
-            - **Stat**: Get file metadata (size, dates, permissions). Prepositions: `from`
-            - **Exists**: Check if a path exists. Prepositions: `for`
-            - **Make**: Create a directory. Prepositions: `for`
-            - **Copy**: Copy file to destination. Prepositions: `to`
-            - **Move**: Move/rename file. Prepositions: `to`
+        let role = roleFilter.flatMap(ActionRole.init(rawValue:))
+        let entries = await AROCatalog.shared.actions(role: role)
 
-            ## SOCKET Actions
-            TCP/WebSocket communication:
+        var output = "# ARO Actions\n\n"
+        output += "ARO has \(entries.count) action verb(s) available"
+        if let directory = directory {
+            output += " (workspace: `\(directory)`)"
+        }
+        output += ".\n\n"
 
-            - **Connect**: Connect to a TCP server. Prepositions: `to`
-            - **Broadcast**: Broadcast message to all connected clients. Prepositions: `to`
-            - **Close**: Close a connection. Prepositions: `for`
+        // Group by role for readability — the catalog gives us a flat list.
+        let order: [(ActionRole, String, String)] = [
+            (.request,  "REQUEST Actions (External → Internal)",  "Bring data into the feature set:"),
+            (.own,      "OWN Actions (Internal → Internal)",      "Transform data within the feature set:"),
+            (.response, "RESPONSE Actions (Internal → External)", "Return results from the feature set:"),
+            (.export,   "EXPORT Actions (Internal → External)",   "Send data outside the feature set:"),
+            (.server,   "SERVER Actions",                          "Control servers, services, and timing:"),
+        ]
 
-            ## TEST Actions
-            Testing framework (Given/When/Then):
+        for (role, title, blurb) in order {
+            if let filter = roleFilter, role.rawValue != filter { continue }
+            let group = entries.filter { $0.role == role && isBuiltIn($0) }
+            guard !group.isEmpty else { continue }
+            output += "## \(title)\n\(blurb)\n\n"
+            for entry in group {
+                output += renderEntryLine(entry)
+            }
+            output += "\n"
+        }
 
-            - **Given**: Set up test context. Prepositions: `with`
-            - **When**: Execute the action under test. Prepositions: `for`
-            - **Then**: Assert expected outcomes. Prepositions: `for`
-            - **Assert**: Make a specific assertion. Prepositions: `for`
-
-            ## SPECIAL Actions
-
-            - **Call**: Call an external plugin action. Prepositions: `with`
-            - **Execute**: Execute a system shell command. Prepositions: `with`
-            - **Include**: Include a template file. Prepositions: `from`
-
-            """
+        // Plugin actions get their own section so users can see what came from
+        // workspace plugins versus the runtime built-ins.
+        let pluginEntries = entries.filter { !isBuiltIn($0) }
+        if !pluginEntries.isEmpty && roleFilter == nil {
+            output += "## Plugin Actions\nProvided by plugins in this workspace:\n\n"
+            for entry in pluginEntries {
+                output += renderEntryLine(entry)
+            }
+            output += "\n"
         }
 
         return MCPToolCallResult(content: [.text(output)])
+    }
+
+    /// List all qualifiers (built-in + plugin), sourced from `AROCatalog`.
+    private func executeQualifiers(arguments: JSONValue?) async -> MCPToolCallResult {
+        let directory = arguments?["directory"]?.stringValue
+        let namespaceFilter = arguments?["namespace"]?.stringValue
+
+        if let directory = directory {
+            let url = URL(fileURLWithPath: directory)
+            _ = await AROCatalog.shared.loadPluginsFromWorkspace(url)
+        }
+
+        let entries = await AROCatalog.shared.qualifiers(namespace: namespaceFilter)
+
+        var output = "# ARO Qualifiers\n\n"
+        output += "Qualifiers transform values inline (`<value: qualifier>`). Plugin "
+        output += "qualifiers are namespaced (`<value: handle.qualifier>`).\n\n"
+
+        let builtIns = entries.filter { $0.namespace.isEmpty }
+        if !builtIns.isEmpty {
+            output += "## Built-in Qualifiers\n\n"
+            for entry in builtIns {
+                output += renderQualifierLine(entry)
+            }
+            output += "\n"
+        }
+
+        let pluginGroups = Dictionary(grouping: entries.filter { !$0.namespace.isEmpty }) { $0.namespace }
+        for namespace in pluginGroups.keys.sorted() {
+            output += "## Plugin Namespace: `\(namespace)`\n\n"
+            for entry in pluginGroups[namespace] ?? [] {
+                output += renderQualifierLine(entry)
+            }
+            output += "\n"
+        }
+
+        if entries.isEmpty {
+            output += "_No qualifiers matched the filter._\n"
+        }
+
+        return MCPToolCallResult(content: [.text(output)])
+    }
+
+    /// Render a single action entry as a markdown bullet.
+    private func renderEntryLine(_ entry: CatalogActionEntry) -> String {
+        let preps = entry.prepositions.isEmpty ? "—" : entry.prepositions.joined(separator: ", ")
+        let desc = entry.description ?? ""
+        var line = "- **\(entry.verb)**: \(desc) Prepositions: `\(preps)`"
+        if case .plugin(let name, let handle) = entry.origin {
+            let handleStr = handle.map { " · handle: `\($0)`" } ?? ""
+            line += " · _from plugin `\(name)`\(handleStr)_"
+        }
+        return line + "\n"
+    }
+
+    /// Render a single qualifier entry as a markdown bullet.
+    private func renderQualifierLine(_ entry: CatalogQualifierEntry) -> String {
+        let inputs = entry.inputTypes.isEmpty ? "any" : entry.inputTypes.joined(separator: ", ")
+        let params = entry.acceptsParameters ? " · accepts `with` parameters" : ""
+        let desc = entry.description ?? ""
+        return "- **\(entry.fullName)**: \(desc) (input: `\(inputs)`)\(params)\n"
+    }
+
+    /// True if a catalog entry came from the built-in runtime (not a plugin).
+    private func isBuiltIn(_ entry: CatalogActionEntry) -> Bool {
+        if case .builtin = entry.origin { return true }
+        return false
     }
 
     /// Parse ARO code to AST
@@ -1293,12 +1300,30 @@ public struct MCPToolProvider: Sendable {
 
         ## Plugin Qualifiers
 
-        Qualifiers are namespaced by `handler:` in plugin.yaml:
+        Plugin qualifiers are **namespaced** via the `handle:` (PascalCase, root-level)
+        or legacy `handler:` (inside `provides:`) field of plugin.yaml. Access them as
+        `<value: handle.qualifier>`:
 
         ```aro
         Compute the <sorted: stats.sort> from the <numbers>.
         Compute the <picked: collections.pick-random> from the <items>.
+        Log <numbers: collections.reverse> to the <console>.
         ```
+
+        Use the `aro_qualifiers` MCP tool to list every qualifier (built-in and
+        plugin-supplied) — pass `directory: <workspace>` to include qualifiers from
+        plugins under `<workspace>/Plugins/`.
+
+        ## Discovering Plugin Actions and Qualifiers
+
+        Both the LSP and MCP layers consult the live `ActionRegistry` and
+        `QualifierRegistry`. To make plugin actions/qualifiers visible:
+
+        - **MCP tools**: pass `directory: <workspace>` to `aro_actions` /
+          `aro_qualifiers` so the workspace's `Plugins/` folder is loaded.
+        - **LSP**: the editor's workspace root is captured during `initialize` and
+          plugins are loaded automatically on `initialized`. Completion and hover
+          will then surface plugin verbs as `Handle.Verb`.
 
         ## Installing Plugins
 

--- a/Sources/ARORuntime/MCP/MCPToolProvider.swift
+++ b/Sources/ARORuntime/MCP/MCPToolProvider.swift
@@ -579,7 +579,7 @@ public struct MCPToolProvider: Sendable {
         }
 
         let role = roleFilter.flatMap(ActionRole.init(rawValue:))
-        let entries = await AROCatalog.shared.actions(role: role)
+        let entries = AROCatalog.shared.actions(role: role)
 
         var output = "# ARO Actions\n\n"
         output += "ARO has \(entries.count) action verb(s) available"
@@ -632,7 +632,7 @@ public struct MCPToolProvider: Sendable {
             _ = await AROCatalog.shared.loadPluginsFromWorkspace(url)
         }
 
-        let entries = await AROCatalog.shared.qualifiers(namespace: namespaceFilter)
+        let entries = AROCatalog.shared.qualifiers(namespace: namespaceFilter)
 
         var output = "# ARO Qualifiers\n\n"
         output += "Qualifiers transform values inline (`<value: qualifier>`). Plugin "

--- a/Sources/ARORuntime/Plugins/NativePluginHost.swift
+++ b/Sources/ARORuntime/Plugins/NativePluginHost.swift
@@ -898,9 +898,12 @@ public final class NativePluginHost: @unchecked Sendable, PluginHostProtocol {
         let language = dict["language"] as? String ?? "native"
 
         // Parse actions using shared helper (supports both flat and structured formats)
-        let parsedActions = Self.parseActionList(from: dict)
+        // The metadata-aware variant also pulls role/prepositions/description so
+        // the catalog can serve completion/hover for plugin verbs.
+        let parsedActions = PluginInfoParser.parseActionListWithMetadata(from: dict)
         let actionNames = parsedActions.names
         let verbsMap = parsedActions.verbsMap
+        let actionMetadata = parsedActions.metadataMap
 
         // Parse qualifiers using shared helper
         let qualifierDescriptors = Self.parseQualifierDescriptors(from: dict)
@@ -969,12 +972,26 @@ public final class NativePluginHost: @unchecked Sendable, PluginHostProtocol {
             deprecations: deprecationList
         )
 
-        // Create action descriptors
+        // Create action descriptors. Stamp the namespace handle onto every entry
+        // so `registerActions()` can register a uniform `PluginActionMetadata`
+        // even though `parseActionListWithMetadata` itself doesn't know the
+        // namespace (that comes from plugin.yaml, not aro_plugin_info JSON).
         for actionName in actionNames {
+            let baseMeta = actionMetadata[actionName]
+            let meta = baseMeta.map {
+                ActionRegistry.PluginActionMetadata(
+                    role: $0.role,
+                    prepositions: $0.prepositions,
+                    description: $0.description,
+                    handle: qualifierNamespace,
+                    since: $0.since
+                )
+            }
             actions[actionName] = NativeActionDescriptor(
                 name: actionName,
                 inputSchema: nil,
-                outputSchema: nil
+                outputSchema: nil,
+                metadata: meta
             )
         }
 
@@ -1057,7 +1074,12 @@ public final class NativePluginHost: @unchecked Sendable, PluginHostProtocol {
 
     /// Register actions with the global action registry
     public func registerActions() {
-        var entries: [(verb: String, pluginName: String, handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable)] = []
+        var entries: [(
+            verb: String,
+            pluginName: String,
+            metadata: ActionRegistry.PluginActionMetadata?,
+            handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable
+        )] = []
 
         for (name, descriptor) in actions {
             // Get verbs for this action (or use the action name itself as a fallback)
@@ -1086,12 +1108,17 @@ public final class NativePluginHost: @unchecked Sendable, PluginHostProtocol {
                         host: self,
                         descriptor: descriptor
                     )
-                    entries.append((verb: registeredVerb, pluginName: pluginName, handler: wrapper.handle))
+                    entries.append((
+                        verb: registeredVerb,
+                        pluginName: pluginName,
+                        metadata: descriptor.metadata,
+                        handler: wrapper.handle
+                    ))
                 }
             }
         }
 
-        syncRegisterActions(entries)
+        syncRegisterActionsWithMetadata(entries)
     }
 
     // MARK: - Unload
@@ -1359,6 +1386,15 @@ struct NativeActionDescriptor: Sendable {
     let name: String
     let inputSchema: String?
     let outputSchema: String?
+    /// Optional metadata parsed from `aro_plugin_info()` for catalog/discovery.
+    let metadata: ActionRegistry.PluginActionMetadata?
+
+    init(name: String, inputSchema: String?, outputSchema: String?, metadata: ActionRegistry.PluginActionMetadata? = nil) {
+        self.name = name
+        self.inputSchema = inputSchema
+        self.outputSchema = outputSchema
+        self.metadata = metadata
+    }
 }
 
 /// Service descriptor (ARO-0073)

--- a/Sources/ARORuntime/Plugins/PluginHostProtocol.swift
+++ b/Sources/ARORuntime/Plugins/PluginHostProtocol.swift
@@ -104,27 +104,54 @@ public enum PluginInfoParser {
     ///
     /// Supports both legacy flat format and structured SDK format:
     /// - Flat: `"actions": ["greet", "farewell"]`
-    /// - Structured: `"actions": [{ "name": "Greet", "verbs": ["greet", "hello"] }]`
+    /// - Structured: `"actions": [{ "name": "Greet", "verbs": ["greet", "hello"], "role": "own", "prepositions": ["from"], "description": "...", "since": "1.0.0" }]`
     ///
     /// - Returns: Tuple of (action names, verbs map from name → verbs)
     public static func parseActionList(from dict: [String: Any]) -> (names: [String], verbsMap: [String: [String]]) {
+        let parsed = parseActionListWithMetadata(from: dict)
+        return (names: parsed.names, verbsMap: parsed.verbsMap)
+    }
+
+    /// Like `parseActionList` but also extracts the metadata (role, prepositions,
+    /// description, since) declared per-action in the structured format. The
+    /// returned `metadataMap` is keyed by action name; flat-format actions get
+    /// no entries (callers should fall back to `.own` / no description).
+    public static func parseActionListWithMetadata(from dict: [String: Any]) -> (
+        names: [String],
+        verbsMap: [String: [String]],
+        metadataMap: [String: ActionRegistry.PluginActionMetadata]
+    ) {
         var actionNames: [String] = []
         var verbsMap: [String: [String]] = [:]
+        var metadataMap: [String: ActionRegistry.PluginActionMetadata] = [:]
 
         if let flatActions = dict["actions"] as? [String] {
             actionNames = flatActions
         } else if let structuredActions = dict["actions"] as? [[String: Any]] {
             for actionObj in structuredActions {
-                if let actionName = actionObj["name"] as? String {
-                    actionNames.append(actionName)
-                    if let verbs = actionObj["verbs"] as? [String] {
-                        verbsMap[actionName] = verbs
-                    }
+                guard let actionName = actionObj["name"] as? String else { continue }
+                actionNames.append(actionName)
+                if let verbs = actionObj["verbs"] as? [String] {
+                    verbsMap[actionName] = verbs
                 }
+
+                let roleString = (actionObj["role"] as? String)?.lowercased() ?? "own"
+                let role = ActionRole(rawValue: roleString) ?? .own
+                let prepositions = actionObj["prepositions"] as? [String] ?? []
+                let description = actionObj["description"] as? String
+                let since = actionObj["since"] as? String
+
+                metadataMap[actionName] = ActionRegistry.PluginActionMetadata(
+                    role: role,
+                    prepositions: prepositions,
+                    description: description,
+                    handle: nil, // host fills this in from qualifierNamespace
+                    since: since
+                )
             }
         }
 
-        return (names: actionNames, verbsMap: verbsMap)
+        return (names: actionNames, verbsMap: verbsMap, metadataMap: metadataMap)
     }
 
     /// Register action verbs with the global `ActionRegistry` using
@@ -134,6 +161,20 @@ public enum PluginInfoParser {
     /// including `PluginLoader`.
     public static func syncRegisterActions(
         _ entries: [(verb: String, pluginName: String?, handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable)]
+    ) {
+        syncRegisterActionsWithMetadata(entries.map { (verb: $0.verb, pluginName: $0.pluginName, metadata: nil, handler: $0.handler) })
+    }
+
+    /// Metadata-aware variant of `syncRegisterActions`. Use this when the host
+    /// has parsed `aro_plugin_info()` and can supply role/prepositions so the
+    /// catalog (and LSP/MCP layers reading it) gets a proper hover card.
+    public static func syncRegisterActionsWithMetadata(
+        _ entries: [(
+            verb: String,
+            pluginName: String?,
+            metadata: ActionRegistry.PluginActionMetadata?,
+            handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable
+        )]
     ) {
         guard !entries.isEmpty else { return }
 
@@ -146,7 +187,8 @@ public enum PluginInfoParser {
                 await ActionRegistry.shared.registerDynamic(
                     verb: entry.verb,
                     handler: entry.handler,
-                    pluginName: entry.pluginName
+                    pluginName: entry.pluginName,
+                    metadata: entry.metadata
                 )
                 semaphore.signal()
             }
@@ -230,6 +272,20 @@ extension PluginHostProtocol {
         _ entries: [(verb: String, pluginName: String, handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable)]
     ) {
         PluginInfoParser.syncRegisterActions(entries.map { ($0.verb, $0.pluginName, $0.handler) })
+    }
+
+    /// Metadata-aware variant for hosts that know per-action metadata.
+    public func syncRegisterActionsWithMetadata(
+        _ entries: [(
+            verb: String,
+            pluginName: String,
+            metadata: ActionRegistry.PluginActionMetadata?,
+            handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable
+        )]
+    ) {
+        PluginInfoParser.syncRegisterActionsWithMetadata(entries.map {
+            (verb: $0.verb, pluginName: $0.pluginName, metadata: $0.metadata, handler: $0.handler)
+        })
     }
 
     // MARK: Unload

--- a/Sources/ARORuntime/Plugins/PythonPluginHost.swift
+++ b/Sources/ARORuntime/Plugins/PythonPluginHost.swift
@@ -64,6 +64,10 @@ public final class PythonPluginHost: @unchecked Sendable, PluginHostProtocol {
     /// Maps verb → canonical action name for structured action descriptors (SDK format)
     private var verbToActionName: [String: String] = [:]
 
+    /// Action metadata parsed from `aro_plugin_info()` (SDK format only).
+    /// Keyed by canonical action name; surfaced to ActionRegistry for catalog hover.
+    private var actionMetadataByName: [String: ActionRegistry.PluginActionMetadata] = [:]
+
     /// Qualifier registrations from this plugin
     public var qualifierRegistrations: [QualifierRegistration] = []
 
@@ -143,9 +147,10 @@ public final class PythonPluginHost: @unchecked Sendable, PluginHostProtocol {
         let qualifierDescriptors = Self.parseQualifierDescriptors(from: json)
 
         // Parse actions: supports both flat [String] (legacy) and structured [[String: Any]] (SDK)
-        // Python uses a flattened verb list with verb→action mapping for SDK format
+        // Python uses a flattened verb list with verb→action mapping for SDK format.
+        // Also captures per-action metadata so the catalog can serve completion/hover.
         var parsedActions: [String] = []
-        let parsedActionList = Self.parseActionList(from: json)
+        let parsedActionList = PluginInfoParser.parseActionListWithMetadata(from: json)
         if !parsedActionList.verbsMap.isEmpty {
             // SDK format: flatten verbs and build reverse mapping
             for name in parsedActionList.names {
@@ -161,6 +166,7 @@ public final class PythonPluginHost: @unchecked Sendable, PluginHostProtocol {
         } else {
             parsedActions = parsedActionList.names
         }
+        actionMetadataByName = parsedActionList.metadataMap
 
         pluginInfo = PythonPluginInfo(
             name: json["name"] as? String ?? pluginName,
@@ -230,7 +236,12 @@ public final class PythonPluginHost: @unchecked Sendable, PluginHostProtocol {
 
     /// Register actions with the global action registry
     public func registerActions() {
-        var entries: [(verb: String, pluginName: String, handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable)] = []
+        var entries: [(
+            verb: String,
+            pluginName: String,
+            metadata: ActionRegistry.PluginActionMetadata?,
+            handler: @Sendable (ResultDescriptor, ObjectDescriptor, any ExecutionContext) async throws -> any Sendable
+        )] = []
 
         for action in actions {
             // When a handler namespace is set, register only as "handler.verb".
@@ -242,15 +253,34 @@ public final class PythonPluginHost: @unchecked Sendable, PluginHostProtocol {
                 registeredVerb = action
             }
 
+            // Resolve metadata via verbToActionName (since `actions` is a flattened
+            // verb set). Fill in the namespace handle from qualifierNamespace.
+            let canonicalName = verbToActionName[action] ?? action
+            let baseMeta = actionMetadataByName[canonicalName]
+            let metadata = baseMeta.map {
+                ActionRegistry.PluginActionMetadata(
+                    role: $0.role,
+                    prepositions: $0.prepositions,
+                    description: $0.description,
+                    handle: qualifierNamespace,
+                    since: $0.since
+                )
+            }
+
             let wrapper = PythonPluginActionWrapper(
                 pluginName: pluginName,
                 actionName: action,
                 host: self
             )
-            entries.append((verb: registeredVerb, pluginName: pluginName, handler: wrapper.handle))
+            entries.append((
+                verb: registeredVerb,
+                pluginName: pluginName,
+                metadata: metadata,
+                handler: wrapper.handle
+            ))
         }
 
-        syncRegisterActions(entries)
+        syncRegisterActionsWithMetadata(entries)
     }
 
     // MARK: - Unload

--- a/Sources/ARORuntime/Plugins/UnifiedPluginLoader.swift
+++ b/Sources/ARORuntime/Plugins/UnifiedPluginLoader.swift
@@ -322,6 +322,16 @@ public final class UnifiedPluginLoader: @unchecked Sendable {
         for action in actions {
             let actionVerbs = action.verbs
 
+            // Build metadata once per manifest action — registered against every
+            // verb (both plain and namespaced) so the catalog can answer hover,
+            // completion, and discovery queries without re-parsing the manifest.
+            let metadata = ActionRegistry.PluginActionMetadata(
+                role: parseActionRole(action.role),
+                prepositions: action.prepositions ?? [],
+                description: action.description,
+                handle: effectiveHandle,
+                since: action.since
+            )
 
             for verb in actionVerbs {
                 // Register both plain verb and namespaced verb (e.g. "hash" and "Hash.hash")
@@ -334,24 +344,30 @@ public final class UnifiedPluginLoader: @unchecked Sendable {
                     let capturedVerb = verb
                     let capturedPlugin = pluginName
                     let capturedLoader = self
+                    let capturedMetadata = metadata
 
                     semaphoreCount += 1
                     Task {
-                        await ActionRegistry.shared.registerDynamic(verb: registeredVerb) { result, object, context in
-                            // Lazy-load on first invocation
-                            let input = Self.buildPluginInput(result: result, object: object, context: context)
-                            if isNative {
-                                let host = try capturedLoader.ensureNativePluginLoaded(pluginName: capturedPlugin)
-                                let output = try host.execute(action: capturedVerb, input: input)
-                                context.bind(result.base, value: output)
-                                return output
-                            } else {
-                                let host = try capturedLoader.ensurePythonPluginLoaded(pluginName: capturedPlugin)
-                                let output = try host.execute(action: capturedVerb, input: input)
-                                context.bind(result.base, value: output)
-                                return output
-                            }
-                        }
+                        await ActionRegistry.shared.registerDynamic(
+                            verb: registeredVerb,
+                            handler: { result, object, context in
+                                // Lazy-load on first invocation
+                                let input = Self.buildPluginInput(result: result, object: object, context: context)
+                                if isNative {
+                                    let host = try capturedLoader.ensureNativePluginLoaded(pluginName: capturedPlugin)
+                                    let output = try host.execute(action: capturedVerb, input: input)
+                                    context.bind(result.base, value: output)
+                                    return output
+                                } else {
+                                    let host = try capturedLoader.ensurePythonPluginLoaded(pluginName: capturedPlugin)
+                                    let output = try host.execute(action: capturedVerb, input: input)
+                                    context.bind(result.base, value: output)
+                                    return output
+                                }
+                            },
+                            pluginName: capturedPlugin,
+                            metadata: capturedMetadata
+                        )
                         semaphore.signal()
                     }
                 }
@@ -361,6 +377,14 @@ public final class UnifiedPluginLoader: @unchecked Sendable {
         for _ in 0..<semaphoreCount {
             semaphore.wait()
         }
+    }
+
+    /// Map a manifest role string ("own", "request", …) to `ActionRole`.
+    /// Falls back to `.own` for unknown values, matching the action runtime
+    /// default for plugin-supplied verbs.
+    private func parseActionRole(_ raw: String?) -> ActionRole {
+        guard let raw = raw?.lowercased() else { return .own }
+        return ActionRole(rawValue: raw) ?? .own
     }
 
     // MARK: - Lazy Load Execution
@@ -1073,15 +1097,15 @@ public struct ManifestActionEntry: Codable, Sendable {
     /// Canonical action name (e.g. "Hash", "Greet").
     public let name: String
     /// Verbs that invoke this action (e.g. ["hash", "digest"]).
-    let verbs: [String]
+    public let verbs: [String]
     /// Semantic role ("own", "request", "response", "export"). Optional.
-    let role: String?
+    public let role: String?
     /// Valid prepositions ("from", "with", …). Optional.
-    let prepositions: [String]?
+    public let prepositions: [String]?
     /// Human-readable description. Optional.
-    let description: String?
+    public let description: String?
     /// Version when this action was introduced. Optional.
-    let since: String?
+    public let since: String?
 }
 
 public struct UnifiedBuildConfig: Codable, Sendable {

--- a/Tests/AROuntimeTests/AROCatalogTests.swift
+++ b/Tests/AROuntimeTests/AROCatalogTests.swift
@@ -14,7 +14,7 @@ struct AROCatalogTests {
 
     @Test("actions() exposes all built-in roles")
     func actionsExposesAllRoles() async {
-        let entries = await AROCatalog.shared.actions()
+        let entries = AROCatalog.shared.actions()
 
         // Built-ins should populate every role at least once.
         let roles = Set(entries.compactMap { entry -> ActionRole? in
@@ -30,7 +30,7 @@ struct AROCatalogTests {
 
     @Test("actions(role:) filters by semantic role")
     func actionsRoleFilter() async {
-        let response = await AROCatalog.shared.actions(role: .response)
+        let response = AROCatalog.shared.actions(role: .response)
         // Only RESPONSE-class verbs should be present.
         #expect(response.allSatisfy { $0.role == .response })
         // "Return" is canonically RESPONSE.
@@ -41,7 +41,7 @@ struct AROCatalogTests {
 
     @Test("Built-in actions carry descriptions")
     func builtInActionsHaveDescriptions() async {
-        let entries = await AROCatalog.shared.actions()
+        let entries = AROCatalog.shared.actions()
         let extract = entries.first { $0.verb.lowercased() == "extract" }
         #expect(extract?.description != nil)
     }
@@ -50,7 +50,7 @@ struct AROCatalogTests {
 
     @Test("qualifiers() returns built-in qualifiers")
     func qualifiersReturnsBuiltIns() async {
-        let entries = await AROCatalog.shared.qualifiers()
+        let entries = AROCatalog.shared.qualifiers()
         // BuiltInQualifierHost registers these; the catalog flattens namespace == "".
         let names = entries.map { $0.qualifier }
         #expect(names.contains("uppercase"))
@@ -60,7 +60,7 @@ struct AROCatalogTests {
 
     @Test("Built-in qualifiers have empty namespace")
     func builtInQualifiersAreUnnamespaced() async {
-        let entries = await AROCatalog.shared.qualifiers()
+        let entries = AROCatalog.shared.qualifiers()
         let upper = entries.first { $0.qualifier == "uppercase" }
         #expect(upper?.namespace == "")
         #expect(upper?.fullName == "uppercase")
@@ -93,7 +93,7 @@ struct AROCatalogTests {
             Task { await ActionRegistry.shared.unregisterPlugin("_catalog_test_plugin_") }
         }
 
-        let entries = await AROCatalog.shared.actions()
+        let entries = AROCatalog.shared.actions()
         let entry = entries.first { $0.verb.lowercased() == verb.lowercased() }
         #expect(entry != nil)
         #expect(entry?.role == .own)
@@ -132,7 +132,7 @@ struct AROCatalogTests {
             if case .builtin = $0.origin { return true }
             return false
         }.count
-        let asyncBuiltInCount = (await AROCatalog.shared.actions()).filter {
+        let asyncBuiltInCount = (AROCatalog.shared.actions()).filter {
             if case .builtin = $0.origin { return true }
             return false
         }.count

--- a/Tests/AROuntimeTests/AROCatalogTests.swift
+++ b/Tests/AROuntimeTests/AROCatalogTests.swift
@@ -1,0 +1,163 @@
+// ============================================================
+// AROCatalogTests.swift
+// Tests for the AROCatalog discovery service (Issue #225)
+// ============================================================
+
+import Testing
+import Foundation
+@testable import ARORuntime
+
+@Suite("AROCatalog Tests")
+struct AROCatalogTests {
+
+    // MARK: - Built-in coverage
+
+    @Test("actions() exposes all built-in roles")
+    func actionsExposesAllRoles() async {
+        let entries = await AROCatalog.shared.actions()
+
+        // Built-ins should populate every role at least once.
+        let roles = Set(entries.compactMap { entry -> ActionRole? in
+            guard case .builtin = entry.origin else { return nil }
+            return entry.role
+        })
+        #expect(roles.contains(.request))
+        #expect(roles.contains(.own))
+        #expect(roles.contains(.response))
+        #expect(roles.contains(.export))
+        #expect(roles.contains(.server))
+    }
+
+    @Test("actions(role:) filters by semantic role")
+    func actionsRoleFilter() async {
+        let response = await AROCatalog.shared.actions(role: .response)
+        // Only RESPONSE-class verbs should be present.
+        #expect(response.allSatisfy { $0.role == .response })
+        // "Return" is canonically RESPONSE.
+        #expect(response.contains { $0.verb.lowercased() == "return" })
+        // "Compute" is OWN, must not appear.
+        #expect(!response.contains { $0.verb.lowercased() == "compute" })
+    }
+
+    @Test("Built-in actions carry descriptions")
+    func builtInActionsHaveDescriptions() async {
+        let entries = await AROCatalog.shared.actions()
+        let extract = entries.first { $0.verb.lowercased() == "extract" }
+        #expect(extract?.description != nil)
+    }
+
+    // MARK: - Qualifiers
+
+    @Test("qualifiers() returns built-in qualifiers")
+    func qualifiersReturnsBuiltIns() async {
+        let entries = await AROCatalog.shared.qualifiers()
+        // BuiltInQualifierHost registers these; the catalog flattens namespace == "".
+        let names = entries.map { $0.qualifier }
+        #expect(names.contains("uppercase"))
+        #expect(names.contains("lowercase"))
+        #expect(names.contains("hash"))
+    }
+
+    @Test("Built-in qualifiers have empty namespace")
+    func builtInQualifiersAreUnnamespaced() async {
+        let entries = await AROCatalog.shared.qualifiers()
+        let upper = entries.first { $0.qualifier == "uppercase" }
+        #expect(upper?.namespace == "")
+        #expect(upper?.fullName == "uppercase")
+    }
+
+    // MARK: - Plugin metadata flow
+
+    @Test("registerDynamic with metadata appears in catalog")
+    func dynamicMetadataFlowsToCatalog() async {
+        // Register a plugin verb directly into ActionRegistry, then verify the
+        // catalog surfaces the metadata. The verb name is unique so this test
+        // doesn't conflict with built-ins.
+        let verb = "issue225_test_verb_xyz"
+        let metadata = ActionRegistry.PluginActionMetadata(
+            role: .own,
+            prepositions: ["from", "with"],
+            description: "A synthetic verb for the catalog test",
+            handle: "TestHandle",
+            since: "1.0.0"
+        )
+
+        await ActionRegistry.shared.registerDynamic(
+            verb: verb,
+            handler: { _, _, _ in NSNull() },
+            pluginName: "_catalog_test_plugin_",
+            metadata: metadata
+        )
+        defer {
+            // Clean up so other tests don't see this verb.
+            Task { await ActionRegistry.shared.unregisterPlugin("_catalog_test_plugin_") }
+        }
+
+        let entries = await AROCatalog.shared.actions()
+        let entry = entries.first { $0.verb.lowercased() == verb.lowercased() }
+        #expect(entry != nil)
+        #expect(entry?.role == .own)
+        #expect(entry?.description == "A synthetic verb for the catalog test")
+        #expect(entry?.prepositions == ["from", "with"])
+        if case .plugin(let name, let handle) = entry?.origin {
+            #expect(name == "_catalog_test_plugin_")
+            #expect(handle == "TestHandle")
+        } else {
+            Issue.record("Expected entry to have plugin origin, got \(String(describing: entry?.origin))")
+        }
+    }
+
+    @Test("ActionRegistry.isRegistered sees dynamic plugin verbs")
+    func isRegisteredFindsDynamicVerbs() async {
+        let verb = "issue225_isregistered_xyz"
+        await ActionRegistry.shared.registerDynamic(
+            verb: verb,
+            handler: { _, _, _ in NSNull() },
+            pluginName: "_isregistered_test_"
+        )
+        defer { Task { await ActionRegistry.shared.unregisterPlugin("_isregistered_test_") } }
+
+        let registered = await ActionRegistry.shared.isRegistered(verb)
+        #expect(registered == true)
+    }
+
+    // MARK: - Synchronous snapshots
+
+    @Test("actionsSnapshot returns built-in actions consistent with async API")
+    func actionsSnapshotReturnsBuiltIns() async {
+        let sync = AROCatalog.actionsSnapshot()
+        // Built-in count is stable across the snapshot and async paths even
+        // when other tests inject transient plugin verbs in parallel.
+        let syncBuiltInCount = sync.filter {
+            if case .builtin = $0.origin { return true }
+            return false
+        }.count
+        let asyncBuiltInCount = (await AROCatalog.shared.actions()).filter {
+            if case .builtin = $0.origin { return true }
+            return false
+        }.count
+        #expect(syncBuiltInCount == asyncBuiltInCount)
+        #expect(syncBuiltInCount > 30) // We have many built-ins.
+    }
+
+    @Test("qualifiersSnapshot returns built-in qualifiers")
+    func qualifiersSnapshotReturnsBuiltIns() {
+        let entries = AROCatalog.qualifiersSnapshot()
+        #expect(entries.contains { $0.qualifier == "uppercase" })
+    }
+
+    // MARK: - Workspace loading
+
+    @Test("loadPluginsFromWorkspace handles missing Plugins dir")
+    func loadPluginsFromMissingDirReturnsFalse() async {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("aro-catalog-test-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let loaded = await AROCatalog.shared.loadPluginsFromWorkspace(tmp)
+        #expect(loaded == false)
+        let hasLoaded = await AROCatalog.shared.hasLoaded(tmp)
+        #expect(hasLoaded == false)
+    }
+}

--- a/Tests/AROuntimeTests/MCPTests.swift
+++ b/Tests/AROuntimeTests/MCPTests.swift
@@ -144,6 +144,7 @@ struct MCPTests {
             #expect(toolNames.contains("aro_compile"))
             #expect(toolNames.contains("aro_examples"))
             #expect(toolNames.contains("aro_actions"))
+            #expect(toolNames.contains("aro_qualifiers"))
             #expect(toolNames.contains("aro_parse"))
             #expect(toolNames.contains("aro_syntax"))
         }
@@ -204,6 +205,43 @@ struct MCPTests {
             #expect(text.contains("Retrieve"))
             // OWN actions should not appear
             #expect(!text.contains("Compute"))
+        }
+
+        @Test("aro_actions rejects unknown role filter")
+        func aroActionsRejectsUnknownRole() async {
+            let provider = MCPToolProvider()
+            let result = await provider.callTool(
+                name: "aro_actions",
+                arguments: .object(["role": .string("nonsense")])
+            )
+            #expect(result.isError == true)
+            #expect(result.content.first?.text?.contains("Unknown role filter") == true)
+        }
+
+        @Test("aro_qualifiers lists built-in qualifiers")
+        func aroQualifiersListsBuiltIns() async {
+            let provider = MCPToolProvider()
+            let result = await provider.callTool(name: "aro_qualifiers", arguments: nil)
+
+            let text = result.content.first?.text ?? ""
+            #expect(text.contains("ARO Qualifiers"))
+            // A few built-ins that QualifierRegistry.registerBuiltIns() registers:
+            #expect(text.contains("uppercase"))
+            #expect(text.contains("lowercase"))
+            #expect(text.contains("hash"))
+        }
+
+        @Test("aro_qualifiers with namespace filter excludes others")
+        func aroQualifiersWithNamespaceFilter() async {
+            let provider = MCPToolProvider()
+            let result = await provider.callTool(
+                name: "aro_qualifiers",
+                arguments: .object(["namespace": .string("")])
+            )
+            // Empty namespace = built-ins only; "Plugin Namespace:" header should
+            // not appear because no plugin entries match.
+            let text = result.content.first?.text ?? ""
+            #expect(!text.contains("Plugin Namespace:"))
         }
 
         @Test("aro_examples returns example list")


### PR DESCRIPTION
Closes #225.

## Summary

The LSP and MCP servers previously hardcoded their list of actions and qualifiers, so plugin-supplied verbs and namespaced qualifiers were invisible to editor completions, hover, and the `aro_actions` MCP tool. This MR introduces a shared **`AROCatalog`** service and threads plugin metadata all the way through to both layers.

After this change:

- The LSP loads plugins from `<workspace>/Plugins/` on `initialized`. Completion, hover, and diagnostics see plugin verbs as first-class citizens (bare + namespaced).
- The MCP server's `aro_actions` tool takes an optional `directory:` argument that triggers workspace plugin loading, and a new `aro_qualifiers` tool lists built-in and plugin qualifiers symmetrically.
- Plugins that declare `role`, `prepositions`, `description`, `handle`, and `since` in `plugin.yaml` (or via structured `aro_plugin_info()`) get rich tooling output for free.

## What Changed

| Area | Change |
|------|--------|
| **AROCatalog** (new) | `Sources/ARORuntime/Catalog/AROCatalog.swift` — actor-backed service wrapping the registries with sync snapshot helpers. Description tables for built-ins migrated out of the LSP/MCP hardcoded arrays. |
| **ActionRegistry** | New `PluginActionMetadata` type; `registerDynamic` overload accepting it; `isRegistered` now also sees dynamic plugin verbs. |
| **PluginHostProtocol** | `parseActionListWithMetadata` and `syncRegisterActionsWithMetadata` so every host can flow per-action metadata uniformly. |
| **UnifiedPluginLoader / Native / Python hosts** | Parse and forward role / prepositions / description / since / handle. |
| **AROLSP** | Captures `rootUri` / `workspaceFolders` in `initialize`; loads workspace plugins on `initialized`. |
| **CompletionHandler** | Reads from catalog (bare + namespaced for plugin qualifiers); plugin verbs tagged in completion docs. |
| **HoverHandler** | Looks up the verb in the catalog so plugin actions get the same hover card as built-ins. |
| **MCPToolProvider** | `aro_actions` rebuilt to render from catalog with a Plugin Actions section; new `aro_qualifiers` tool; `aro_syntax plugins` topic mentions namespaced form and `directory:` flow. |
| **Package.swift** | AROLSP now depends on ARORuntime. |

## Tests

- **New `Tests/AROuntimeTests/AROCatalogTests.swift`** (10 tests): role coverage, role filtering, built-in qualifier visibility, dynamic-metadata round-trip, `isRegistered` plugin lookups, sync snapshots, missing-Plugins-dir graceful fallback.
- **`Tests/AROuntimeTests/MCPTests.swift`**: `aro_qualifiers` listing, namespace filtering, unknown-role rejection on `aro_actions`.
- Full suite: **1714 tests, 0 failures**.

## Docs

- **TheLanguageGuide Chapter 26 (Plugins)**: new section §26.14 "Tooling Discovery (LSP and MCP)"; `metadata:` example added to the registry section.
- **ThePluginGuide Appendix A**: `since:` field added to the action specification table; explicit mention that LSP/MCP consume these fields.
- **Wiki**: new "Editor & AI Tooling Discovery" page (`Guide-IDE-Tooling.md`) with a sidebar entry — pushed to `arolang/aro.wiki`.
- **README** and **OVERVIEW.md**: short note about plugin discovery in tooling.

## Open Decisions Carried Forward

The proposal in #225 lists three open decisions; this MR takes the **least-invasive** path on each:

- **Plugin loading in the LSP process**: enabled by default. We can revisit behind an init option (`aro.lsp.loadPlugins`) if anyone reports concerns.
- **`aro_actions` workspace argument**: kept optional. Built-ins are listed when omitted, plugins on top when supplied.
- **Manifest-only vs. live-loaded for LSP**: live-loaded today (`UnifiedPluginLoader`), but the catalog itself is agnostic — a manifest-only path can be added later without touching consumers.

## Test plan

- [ ] Open an ARO project with plugins in VS Code (or similar LSP client) and confirm plugin verbs appear in `<` completion with their source plugin in the docs.
- [ ] Hover a plugin verb and confirm the `_Provided by plugin **<name>**_` line appears.
- [ ] Run `aro mcp call aro_actions --directory $(pwd)` against a plugin-bearing project and confirm a Plugin Actions section.
- [ ] Run `aro mcp call aro_qualifiers --directory $(pwd)` and confirm namespaced plugin qualifiers appear.
- [ ] `swift test` — should report 1714 passing tests.
